### PR TITLE
feat(Automatic mode): :sparkles: Implementado modo automatic

### DIFF
--- a/src/MagicAction.h
+++ b/src/MagicAction.h
@@ -7,4 +7,5 @@ namespace IntegratedMagic::MagicAction {
     RE::ActorMagicCaster* GetCaster(RE::PlayerCharacter* player, RE::MagicSystem::CastingSource source);
     void EquipSpellInHand(RE::PlayerCharacter* player, RE::SpellItem* spell, EquipHand hand);
     void ClearHandSpell(RE::PlayerCharacter* player, EquipHand hand);
+    void ClearHandSpell(RE::PlayerCharacter* player, RE::SpellItem* spell, EquipHand hand);
 }

--- a/src/MagicState.h
+++ b/src/MagicState.h
@@ -30,42 +30,54 @@ namespace IntegratedMagic {
             RE::ExtraDataList* extra{nullptr};
         };
 
-        std::vector<ExtraEquippedItem> _prevExtraEquipped;
-
         void TogglePress(int slot);
+        void ToggleAutomatic(int slot);
         bool IsActive() const;
         int ActiveSlot() const;
         void HoldDown(int slot);
         void HoldUp(int slot);
         bool IsHoldActive() const { return _holdActive; }
         int HoldSlot() const { return _holdSlot; }
+        bool IsAutomaticActive() const { return _autoActive; }
+        int AutomaticSlot() const { return _autoSlot; }
         void StartAutoAttack(EquipHand hand);
         void StopAutoAttack();
         void PumpAutoAttack(float dt);
         void NotifyAttackEnabled();
         void RequestAutoAttackStart(EquipHand hand);
         void TryStartWaitingAutoAttack();
+        void PumpAutomatic();
+        void AutoExit();
 
     private:
         void EnterPress(int slot);
         bool ApplyPress(int slot);
         void EnterHold(int slot);
+        void EnterAutomatic(int slot);
         void ExitAll();
 
         void CaptureSnapshot(RE::PlayerCharacter* player);
         void RestoreSnapshot(RE::PlayerCharacter* player);
         void UpdatePrevExtraEquippedForOverlay(const std::function<void()>& equipFn);
 
+        std::vector<ExtraEquippedItem> _prevExtraEquipped;
         bool _active{false};
         int _activeSlot{-1};
         bool _holdActive{false};
         int _holdSlot{-1};
+        bool _autoActive{false};
+        int _autoSlot{-1};
+        EquipHand _autoHand{EquipHand::Right};
+        bool _autoWaitingChargeComplete{false};
+        bool _autoChargeComplete{false};
         HandSnapshot _snap{};
         bool _autoAttackHeld{false};
         EquipHand _autoAttackHand{EquipHand::Right};
         float _autoAttackSecs{0.0f};
-        bool _attackEnabled = false;
-        bool _waitingAutoAfterEquip = false;
-        EquipHand _waitingAutoHand = EquipHand::Right;
+        bool _attackEnabled{false};
+        bool _waitingAutoAfterEquip{false};
+        EquipHand _waitingAutoHand{EquipHand::Right};
+        RE::SpellItem* _modeSpellLeft{nullptr};
+        RE::SpellItem* _modeSpellRight{nullptr};
     };
 }


### PR DESCRIPTION
Foi implementado o modo automatic que entra na spell, usa e sai. Além disso foi corrigido o clearSpell para usar uma referencia a spell salva em MagicState e usar o getFromCaster apenas como fallback.

## Summary by Sourcery

Add an automatic activation mode for spells that equips, auto-casts, and restores state once casting completes.

New Features:
- Introduce an Automatic activation mode for spell slots that handles equipping, charging, casting, and exiting automatically.
- Track automatic-mode state per hand and slot, including auto-attack timing and spell references, to coordinate casting flow.

Bug Fixes:
- Ensure hand spells are cleared using the saved mode spell reference from MagicState, falling back to the current caster spell only when necessary.
- Prevent input handlers and attack notifications from interfering while hold or automatic modes are active.

Enhancements:
- Centralize magicka availability checks before entering automatic mode to avoid attempting casts without sufficient magicka.
- Improve spell unequip logic to use the engine’s equip manager, including dual-cast handling and safer caster spell lookup.
- Reset all mode and auto-attack state on exit to avoid lingering flags between activations.