### PR TITLE
feat(Save): :sparkles: Adicionado o save das spells escolhidas por save

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,9 @@ add_commonlibsse_plugin(${PROJECT_NAME}
     src/Detours/image.cpp
     src/Detours/modules.cpp
     src/MagicState.cpp
-    src/MagicAction.cpp) 
+    src/MagicAction.cpp
+    src/SaveSpellDB.cpp
+) 
 
 target_include_directories(${PROJECT_NAME}
   PRIVATE
@@ -60,7 +62,9 @@ target_precompile_headers(${PROJECT_NAME}
     src/MagicHooks.h
     src/MagicState.h
     src/MagicAction.h
-    src/MagicEquipSlots.h) 
+    src/MagicEquipSlots.h
+    src/SaveSpellDB.h
+) 
 
 set_source_files_properties(
   src/Detours/detours.cpp

--- a/src/MagicConfig.cpp
+++ b/src/MagicConfig.cpp
@@ -54,16 +54,12 @@ namespace IntegratedMagic {
             return;
         }
 
-        holdThresholdSeconds.store(_getFloat(ini, "General", "HoldThresholdSeconds", 0.20f), std::memory_order_relaxed);
-
         Magic1Input.KeyboardScanCode1.store(_getInt(ini, "Magic1", "KeyboardScanCode1", -1), std::memory_order_relaxed);
         Magic1Input.KeyboardScanCode2.store(_getInt(ini, "Magic1", "KeyboardScanCode2", -1), std::memory_order_relaxed);
         Magic1Input.KeyboardScanCode3.store(_getInt(ini, "Magic1", "KeyboardScanCode3", -1), std::memory_order_relaxed);
         Magic1Input.GamepadButton1.store(_getInt(ini, "Magic1", "GamepadButton1", -1), std::memory_order_relaxed);
         Magic1Input.GamepadButton2.store(_getInt(ini, "Magic1", "GamepadButton2", -1), std::memory_order_relaxed);
         Magic1Input.GamepadButton3.store(_getInt(ini, "Magic1", "GamepadButton3", -1), std::memory_order_relaxed);
-        slotSpellFormID1.store(static_cast<std::uint32_t>(_getInt(ini, "Magic1", "SpellFormID", 0)),
-                               std::memory_order_relaxed);
 
         Magic2Input.KeyboardScanCode1.store(_getInt(ini, "Magic2", "KeyboardScanCode1", -1), std::memory_order_relaxed);
         Magic2Input.KeyboardScanCode2.store(_getInt(ini, "Magic2", "KeyboardScanCode2", -1), std::memory_order_relaxed);
@@ -71,8 +67,6 @@ namespace IntegratedMagic {
         Magic2Input.GamepadButton1.store(_getInt(ini, "Magic2", "GamepadButton1", -1), std::memory_order_relaxed);
         Magic2Input.GamepadButton2.store(_getInt(ini, "Magic2", "GamepadButton2", -1), std::memory_order_relaxed);
         Magic2Input.GamepadButton3.store(_getInt(ini, "Magic2", "GamepadButton3", -1), std::memory_order_relaxed);
-        slotSpellFormID2.store(static_cast<std::uint32_t>(_getInt(ini, "Magic2", "SpellFormID", 0)),
-                               std::memory_order_relaxed);
 
         Magic3Input.KeyboardScanCode1.store(_getInt(ini, "Magic3", "KeyboardScanCode1", -1), std::memory_order_relaxed);
         Magic3Input.KeyboardScanCode2.store(_getInt(ini, "Magic3", "KeyboardScanCode2", -1), std::memory_order_relaxed);
@@ -80,8 +74,6 @@ namespace IntegratedMagic {
         Magic3Input.GamepadButton1.store(_getInt(ini, "Magic3", "GamepadButton1", -1), std::memory_order_relaxed);
         Magic3Input.GamepadButton2.store(_getInt(ini, "Magic3", "GamepadButton2", -1), std::memory_order_relaxed);
         Magic3Input.GamepadButton3.store(_getInt(ini, "Magic3", "GamepadButton3", -1), std::memory_order_relaxed);
-        slotSpellFormID3.store(static_cast<std::uint32_t>(_getInt(ini, "Magic3", "SpellFormID", 0)),
-                               std::memory_order_relaxed);
 
         Magic4Input.KeyboardScanCode1.store(_getInt(ini, "Magic4", "KeyboardScanCode1", -1), std::memory_order_relaxed);
         Magic4Input.KeyboardScanCode2.store(_getInt(ini, "Magic4", "KeyboardScanCode2", -1), std::memory_order_relaxed);
@@ -89,8 +81,6 @@ namespace IntegratedMagic {
         Magic4Input.GamepadButton1.store(_getInt(ini, "Magic4", "GamepadButton1", -1), std::memory_order_relaxed);
         Magic4Input.GamepadButton2.store(_getInt(ini, "Magic4", "GamepadButton2", -1), std::memory_order_relaxed);
         Magic4Input.GamepadButton3.store(_getInt(ini, "Magic4", "GamepadButton3", -1), std::memory_order_relaxed);
-        slotSpellFormID4.store(static_cast<std::uint32_t>(_getInt(ini, "Magic4", "SpellFormID", 0)),
-                               std::memory_order_relaxed);
 
         skipEquipAnimationPatch = _getBool(ini, "Patches", "SkipEquipAnimationPatch", false);
     }
@@ -101,16 +91,12 @@ namespace IntegratedMagic {
         const auto path = IniPath();
         ini.LoadFile(path.string().c_str());
 
-        ini.SetDoubleValue("General", "HoldThresholdSeconds",
-                           static_cast<double>(holdThresholdSeconds.load(std::memory_order_relaxed)));
-
         ini.SetLongValue("Magic1", "KeyboardScanCode1", Magic1Input.KeyboardScanCode1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic1", "KeyboardScanCode2", Magic1Input.KeyboardScanCode2.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic1", "KeyboardScanCode3", Magic1Input.KeyboardScanCode3.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic1", "GamepadButton1", Magic1Input.GamepadButton1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic1", "GamepadButton2", Magic1Input.GamepadButton2.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic1", "GamepadButton3", Magic1Input.GamepadButton3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic1", "SpellFormID", static_cast<long>(slotSpellFormID1.load(std::memory_order_relaxed)));
 
         ini.SetLongValue("Magic2", "KeyboardScanCode1", Magic2Input.KeyboardScanCode1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic2", "KeyboardScanCode2", Magic2Input.KeyboardScanCode2.load(std::memory_order_relaxed));
@@ -118,7 +104,6 @@ namespace IntegratedMagic {
         ini.SetLongValue("Magic2", "GamepadButton1", Magic2Input.GamepadButton1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic2", "GamepadButton2", Magic2Input.GamepadButton2.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic2", "GamepadButton3", Magic2Input.GamepadButton3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic2", "SpellFormID", static_cast<long>(slotSpellFormID2.load(std::memory_order_relaxed)));
 
         ini.SetLongValue("Magic3", "KeyboardScanCode1", Magic3Input.KeyboardScanCode1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic3", "KeyboardScanCode2", Magic3Input.KeyboardScanCode2.load(std::memory_order_relaxed));
@@ -126,7 +111,6 @@ namespace IntegratedMagic {
         ini.SetLongValue("Magic3", "GamepadButton1", Magic3Input.GamepadButton1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic3", "GamepadButton2", Magic3Input.GamepadButton2.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic3", "GamepadButton3", Magic3Input.GamepadButton3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic3", "SpellFormID", static_cast<long>(slotSpellFormID3.load(std::memory_order_relaxed)));
 
         ini.SetLongValue("Magic4", "KeyboardScanCode1", Magic4Input.KeyboardScanCode1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic4", "KeyboardScanCode2", Magic4Input.KeyboardScanCode2.load(std::memory_order_relaxed));
@@ -134,7 +118,6 @@ namespace IntegratedMagic {
         ini.SetLongValue("Magic4", "GamepadButton1", Magic4Input.GamepadButton1.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic4", "GamepadButton2", Magic4Input.GamepadButton2.load(std::memory_order_relaxed));
         ini.SetLongValue("Magic4", "GamepadButton3", Magic4Input.GamepadButton3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic4", "SpellFormID", static_cast<long>(slotSpellFormID4.load(std::memory_order_relaxed)));
 
         ini.SetBoolValue("Patches", "SkipEquipAnimationPatch", skipEquipAnimationPatch);
 

--- a/src/MagicConfig.h
+++ b/src/MagicConfig.h
@@ -15,8 +15,6 @@ namespace IntegratedMagic {
     };
 
     struct MagicConfig {
-        std::atomic<float> holdThresholdSeconds{0.20f};
-
         std::atomic<std::uint32_t> slotSpellFormID1{0};
         std::atomic<std::uint32_t> slotSpellFormID2{0};
         std::atomic<std::uint32_t> slotSpellFormID3{0};

--- a/src/SaveSpellDB.cpp
+++ b/src/SaveSpellDB.cpp
@@ -1,0 +1,120 @@
+#include "SaveSpellDB.h"
+
+#include <fstream>
+#include <nlohmann/json.hpp>
+
+#include "PCH.h"
+
+namespace IntegratedMagic {
+    SaveSpellDB& SaveSpellDB::Get() {
+        static SaveSpellDB g;  // NOSONAR
+        return g;
+    }
+
+    std::filesystem::path SaveSpellDB::JsonPath() { return GetThisDllDir() / "SaveSpells.json"; }
+
+    std::string SaveSpellDB::NormalizeKey(std::string key) {
+        for (auto& c : key) {
+            if (c == '/') c = '\\';
+            c = static_cast<char>(::tolower(static_cast<unsigned char>(c)));
+        }
+        return key;
+    }
+
+    void SaveSpellDB::LoadFromDisk() {
+        std::scoped_lock lk(_mtx);
+
+        _bySave.clear();
+
+        const auto path = JsonPath();
+
+        std::ifstream in(path);
+        if (!in.good()) {
+            return;
+        }
+
+        nlohmann::json j = nlohmann::json::parse(in, nullptr, false);
+        if (j.is_discarded()) {
+            return;
+        }
+
+        auto savesIt = j.find("saves");
+        if (savesIt == j.end()) {
+            return;
+        }
+        if (!savesIt->is_object()) {
+            return;
+        }
+
+        for (auto it = savesIt->begin(); it != savesIt->end(); ++it) {
+            try {
+                const std::string rawKey = it.key();
+                const std::string key = NormalizeKey(rawKey);
+
+                const auto& arr = it.value();
+
+                if (!arr.is_array()) {
+                    continue;
+                }
+                if (arr.size() != 4) {
+                    continue;
+                }
+
+                SaveSpellSlots slots{};
+
+                for (std::size_t i = 0; i < 4; ++i) {
+                    slots.slotSpellFormID[i] = arr[i].get<std::uint32_t>();
+                }
+
+                _bySave[key] = slots;
+
+            } catch (const std::exception& e) {
+                spdlog::error("[IMAGIC][SaveSpellDB] Exception while reading entry: {}", e.what());
+
+            } catch (...) {
+                spdlog::error("[IMAGIC][SaveSpellDB] Unknown exception while reading entry");
+            }
+        }
+    }
+
+    void SaveSpellDB::SaveToDisk() {
+        std::scoped_lock lk(_mtx);
+
+        nlohmann::json j;
+        j["version"] = 1;
+
+        nlohmann::json saves = nlohmann::json::object();
+        for (auto const& [key, slots] : _bySave) {
+            saves[key] = nlohmann::json::array({slots.slotSpellFormID[0], slots.slotSpellFormID[1],
+                                                slots.slotSpellFormID[2], slots.slotSpellFormID[3]});
+        }
+        j["saves"] = std::move(saves);
+
+        const auto path = JsonPath();
+        std::error_code ec;
+        std::filesystem::create_directories(path.parent_path(), ec);
+
+        std::ofstream out(path);
+        out << j.dump(2);
+    }
+
+    void SaveSpellDB::Upsert(const std::string& saveKey, const SaveSpellSlots& slots) {
+        std::scoped_lock lk(_mtx);
+        _bySave[NormalizeKey(saveKey)] = slots;
+    }
+
+    bool SaveSpellDB::TryGet(const std::string& saveKey, SaveSpellSlots& out) const {
+        std::scoped_lock lk(_mtx);
+        auto it = _bySave.find(NormalizeKey(saveKey));
+        if (it == _bySave.end()) {
+            return false;
+        }
+        out = it->second;
+        return true;
+    }
+
+    void SaveSpellDB::Erase(const std::string& saveKey) {
+        std::scoped_lock lk(_mtx);
+        _bySave.erase(NormalizeKey(saveKey));
+    }
+}

--- a/src/SaveSpellDB.h
+++ b/src/SaveSpellDB.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace IntegratedMagic {
+    struct SaveSpellSlots {
+        std::array<std::uint32_t, 4> slotSpellFormID{{0, 0, 0, 0}};
+    };
+
+    class SaveSpellDB {
+    public:
+        static SaveSpellDB& Get();
+
+        void LoadFromDisk();
+        void SaveToDisk();
+
+        void Upsert(const std::string& saveKey, const SaveSpellSlots& slots);
+        bool TryGet(const std::string& saveKey, SaveSpellSlots& out) const;
+        void Erase(const std::string& saveKey);
+
+        static std::filesystem::path JsonPath();
+        static std::string NormalizeKey(std::string key);
+
+    private:
+        SaveSpellDB() = default;
+
+        mutable std::mutex _mtx;
+        std::unordered_map<std::string, SaveSpellSlots> _bySave;
+    };
+}


### PR DESCRIPTION
## Summary by Sourcery

Persist selected spell slots per save file and integrate this persistence with SKSE game lifecycle events.

New Features:
- Introduce a SaveSpellDB component that stores spell slot selections per save in a JSON file.
- Load and apply per-save spell slot selections when a game is loaded, and update them when a game is saved or deleted.

Enhancements:
- Stop reading and writing spell slot form IDs and hold-threshold configuration from the INI file in favor of the new per-save storage.
- Wire the new SaveSpellDB sources and headers into the build configuration and precompiled headers.