### PR TITLE
fix(losing weapon ref): :bug: Resolvido bug em que perdia referencia …

### DIFF
--- a/src/MagicState.h
+++ b/src/MagicState.h
@@ -62,8 +62,6 @@ namespace IntegratedMagic {
 
         void TogglePress(int slot);
         void ToggleAutomatic(int slot);
-        bool IsActive() const;
-        int ActiveSlot() const;
         void HoldDown(int slot);
         void HoldUp(int slot);
         bool IsHoldActive() const { return _holdActive; }


### PR DESCRIPTION
…ao extra das arma que causava a arma não ser reequipada ou ser equipada na mão errada

## Summary by Sourcery

Improve input state handling around menu blocking and fix weapon re‑equip behavior by correctly tracking equipped item extras per hand.

Bug Fixes:
- Preserve and restore correct weapon instances on re‑equip by selecting the appropriate worn ExtraData per hand and queuing equipment when the specific instance is unavailable.
- Prevent weapons from being equipped in the wrong hand by distinguishing left and right hand worn extras.
- Avoid losing or corrupting input state when menus are closed by clearing only edge state and likely stuck keys instead of fully resetting key down caches while input is blocked.

Enhancements:
- Refine input blocking flow to early‑return on blocked state and recompute slot edges only when input is active.
- Simplify MagicState interface by removing unused active state accessors.