### PR TITLE
fix: :bug: Corrigido problema que não conseguia selecinar as magias p…

### DIFF
--- a/src/MagicSelect.h
+++ b/src/MagicSelect.h
@@ -10,7 +10,7 @@ namespace RE {
 }
 
 namespace IntegratedMagic::MagicSelect {
-    bool TrySelectSpellFromEquip(RE::Actor* actor, RE::SpellItem* spell);
+    bool TrySelectSpellFromEquip(RE::SpellItem* spell);
 
     class ScopedSuppressSelection {
     public:

--- a/src/MagicState.cpp
+++ b/src/MagicState.cpp
@@ -84,7 +84,7 @@ namespace IntegratedMagic {
     namespace {
         inline RE::PlayerCharacter* GetPlayer() { return RE::PlayerCharacter::GetSingleton(); }
 
-        static RE::ExtraDataList* GetWornExtraForHand(RE::InventoryEntryData* entry, bool leftHand) {
+        RE::ExtraDataList* GetWornExtraForHand(RE::InventoryEntryData* entry, bool leftHand) {
             if (!entry || !entry->extraLists) {
                 return nullptr;
             }


### PR DESCRIPTION
…ara slots multiplas vezes em sequencia

## Summary by Sourcery

Fix spell selection from equipment so spells can be assigned to slots multiple times in sequence without being blocked by internal suppression state.

Bug Fixes:
- Allow consecutive spell-to-slot selections by replacing the boolean suppression flag with a reentrant depth counter and ensuring suppression is scoped correctly around slot assignment.
- Prevent crashes or no-ops when trying to select a spell without a valid spell instance or selection slot.

Enhancements:
- Simplify the spell selection hook flow by removing the atomic swallow-next-select flag and letting the selection helper handle suppression internally.
- Clean up MagicSelect API by removing the unused actor parameter from TrySelectSpellFromEquip and tightening player checks to the hook layer.