### PR TITLE
feat: :sparkles: Permiti modificar o número de slots para magia

### DIFF
--- a/src/MagicConfig.cpp
+++ b/src/MagicConfig.cpp
@@ -2,6 +2,8 @@
 
 #include <SimpleIni.h>
 
+#include <algorithm>
+#include <format>
 #include <string>
 
 #include "MagicConfigPath.h"
@@ -12,75 +14,93 @@ using namespace std::string_literals;
 namespace {
     int _getInt(CSimpleIniA& ini, const char* sec, const char* k, int defVal) {
         const char* v = ini.GetValue(sec, k, nullptr);
-        if (!v) return defVal;
+        if (!v) {
+            return defVal;
+        }
         char* end = nullptr;
         long r = std::strtol(v, &end, 10);
-        if (!end || end == v) return defVal;
+        if (!end || end == v) {
+            return defVal;
+        }
         return static_cast<int>(r);
-    }
-
-    float _getFloat(CSimpleIniA& ini, const char* sec, const char* k, float defVal) {
-        const char* v = ini.GetValue(sec, k, nullptr);
-        if (!v) return defVal;
-        char* end = nullptr;
-        double r = std::strtod(v, &end);
-        if (!end || end == v) return defVal;
-        return static_cast<float>(r);
     }
 
     bool _getBool(CSimpleIniA& ini, const char* sec, const char* k, bool defVal) {
         const char* v = ini.GetValue(sec, k, nullptr);
-        if (!v) return defVal;
+        if (!v) {
+            return defVal;
+        }
         return (_stricmp(v, "true") == 0 || std::strcmp(v, "1") == 0);
     }
 
-    std::string _getStr(CSimpleIniA& ini, const char* sec, const char* k, const char* defVal) {
-        const char* v = ini.GetValue(sec, k, nullptr);
-        return v ? std::string{v} : std::string{defVal};
+    void _loadInput(CSimpleIniA& ini, const char* sec, IntegratedMagic::InputConfig& out) {
+        out.KeyboardScanCode1.store(_getInt(ini, sec, "KeyboardScanCode1", -1), std::memory_order_relaxed);
+        out.KeyboardScanCode2.store(_getInt(ini, sec, "KeyboardScanCode2", -1), std::memory_order_relaxed);
+        out.KeyboardScanCode3.store(_getInt(ini, sec, "KeyboardScanCode3", -1), std::memory_order_relaxed);
+
+        out.GamepadButton1.store(_getInt(ini, sec, "GamepadButton1", -1), std::memory_order_relaxed);
+        out.GamepadButton2.store(_getInt(ini, sec, "GamepadButton2", -1), std::memory_order_relaxed);
+        out.GamepadButton3.store(_getInt(ini, sec, "GamepadButton3", -1), std::memory_order_relaxed);
+    }
+
+    void _saveInput(CSimpleIniA& ini, const char* sec, const IntegratedMagic::InputConfig& in) {
+        ini.SetLongValue(sec, "KeyboardScanCode1", in.KeyboardScanCode1.load(std::memory_order_relaxed));
+        ini.SetLongValue(sec, "KeyboardScanCode2", in.KeyboardScanCode2.load(std::memory_order_relaxed));
+        ini.SetLongValue(sec, "KeyboardScanCode3", in.KeyboardScanCode3.load(std::memory_order_relaxed));
+
+        ini.SetLongValue(sec, "GamepadButton1", in.GamepadButton1.load(std::memory_order_relaxed));
+        ini.SetLongValue(sec, "GamepadButton2", in.GamepadButton2.load(std::memory_order_relaxed));
+        ini.SetLongValue(sec, "GamepadButton3", in.GamepadButton3.load(std::memory_order_relaxed));
     }
 }
 
 namespace IntegratedMagic {
+
+    MagicConfig::MagicConfig() {
+        for (auto& a : slotSpellFormID) {
+            a.store(0u, std::memory_order_relaxed);
+        }
+    }
+
     std::filesystem::path MagicConfig::IniPath() {
         const auto& base = GetThisDllDir();
         return base / "IntegratedMagic.ini";
     }
 
+    std::uint32_t MagicConfig::SlotCount() const noexcept {
+        auto v = slotCount.load(std::memory_order_relaxed);
+        if (v < 1u) {
+            v = 1u;
+        } else if (v > kMaxSlots) {
+            v = kMaxSlots;
+        }
+        return v;
+    }
+
     void MagicConfig::Load() {
         CSimpleIniA ini;
         ini.SetUnicode();
+
         const auto path = IniPath();
         if (SI_Error rc = ini.LoadFile(path.string().c_str()); rc < 0) {
             return;
         }
 
-        Magic1Input.KeyboardScanCode1.store(_getInt(ini, "Magic1", "KeyboardScanCode1", -1), std::memory_order_relaxed);
-        Magic1Input.KeyboardScanCode2.store(_getInt(ini, "Magic1", "KeyboardScanCode2", -1), std::memory_order_relaxed);
-        Magic1Input.KeyboardScanCode3.store(_getInt(ini, "Magic1", "KeyboardScanCode3", -1), std::memory_order_relaxed);
-        Magic1Input.GamepadButton1.store(_getInt(ini, "Magic1", "GamepadButton1", -1), std::memory_order_relaxed);
-        Magic1Input.GamepadButton2.store(_getInt(ini, "Magic1", "GamepadButton2", -1), std::memory_order_relaxed);
-        Magic1Input.GamepadButton3.store(_getInt(ini, "Magic1", "GamepadButton3", -1), std::memory_order_relaxed);
+        {
+            const int raw = _getInt(ini, "General", "SlotCount", 4);
+            std::uint32_t v = (raw < 1) ? 1u : static_cast<std::uint32_t>(raw);
+            if (v > kMaxSlots) {
+                v = kMaxSlots;
+            }
+            slotCount.store(v, std::memory_order_relaxed);
+        }
 
-        Magic2Input.KeyboardScanCode1.store(_getInt(ini, "Magic2", "KeyboardScanCode1", -1), std::memory_order_relaxed);
-        Magic2Input.KeyboardScanCode2.store(_getInt(ini, "Magic2", "KeyboardScanCode2", -1), std::memory_order_relaxed);
-        Magic2Input.KeyboardScanCode3.store(_getInt(ini, "Magic2", "KeyboardScanCode3", -1), std::memory_order_relaxed);
-        Magic2Input.GamepadButton1.store(_getInt(ini, "Magic2", "GamepadButton1", -1), std::memory_order_relaxed);
-        Magic2Input.GamepadButton2.store(_getInt(ini, "Magic2", "GamepadButton2", -1), std::memory_order_relaxed);
-        Magic2Input.GamepadButton3.store(_getInt(ini, "Magic2", "GamepadButton3", -1), std::memory_order_relaxed);
+        const auto n = SlotCount();
 
-        Magic3Input.KeyboardScanCode1.store(_getInt(ini, "Magic3", "KeyboardScanCode1", -1), std::memory_order_relaxed);
-        Magic3Input.KeyboardScanCode2.store(_getInt(ini, "Magic3", "KeyboardScanCode2", -1), std::memory_order_relaxed);
-        Magic3Input.KeyboardScanCode3.store(_getInt(ini, "Magic3", "KeyboardScanCode3", -1), std::memory_order_relaxed);
-        Magic3Input.GamepadButton1.store(_getInt(ini, "Magic3", "GamepadButton1", -1), std::memory_order_relaxed);
-        Magic3Input.GamepadButton2.store(_getInt(ini, "Magic3", "GamepadButton2", -1), std::memory_order_relaxed);
-        Magic3Input.GamepadButton3.store(_getInt(ini, "Magic3", "GamepadButton3", -1), std::memory_order_relaxed);
-
-        Magic4Input.KeyboardScanCode1.store(_getInt(ini, "Magic4", "KeyboardScanCode1", -1), std::memory_order_relaxed);
-        Magic4Input.KeyboardScanCode2.store(_getInt(ini, "Magic4", "KeyboardScanCode2", -1), std::memory_order_relaxed);
-        Magic4Input.KeyboardScanCode3.store(_getInt(ini, "Magic4", "KeyboardScanCode3", -1), std::memory_order_relaxed);
-        Magic4Input.GamepadButton1.store(_getInt(ini, "Magic4", "GamepadButton1", -1), std::memory_order_relaxed);
-        Magic4Input.GamepadButton2.store(_getInt(ini, "Magic4", "GamepadButton2", -1), std::memory_order_relaxed);
-        Magic4Input.GamepadButton3.store(_getInt(ini, "Magic4", "GamepadButton3", -1), std::memory_order_relaxed);
+        for (std::uint32_t i = 0; i < n; ++i) {
+            const auto sec = std::format("Magic{}", i + 1);
+            _loadInput(ini, sec.c_str(), slotInput[i]);
+        }
 
         skipEquipAnimationPatch = _getBool(ini, "Patches", "SkipEquipAnimationPatch", false);
         requireExclusiveHotkeyPatch = _getBool(ini, "Patches", "RequireExclusiveHotkeyPatch", false);
@@ -89,36 +109,18 @@ namespace IntegratedMagic {
     void MagicConfig::Save() const {
         CSimpleIniA ini;
         ini.SetUnicode();
+
         const auto path = IniPath();
         ini.LoadFile(path.string().c_str());
 
-        ini.SetLongValue("Magic1", "KeyboardScanCode1", Magic1Input.KeyboardScanCode1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic1", "KeyboardScanCode2", Magic1Input.KeyboardScanCode2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic1", "KeyboardScanCode3", Magic1Input.KeyboardScanCode3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic1", "GamepadButton1", Magic1Input.GamepadButton1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic1", "GamepadButton2", Magic1Input.GamepadButton2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic1", "GamepadButton3", Magic1Input.GamepadButton3.load(std::memory_order_relaxed));
+        const auto n = SlotCount();
 
-        ini.SetLongValue("Magic2", "KeyboardScanCode1", Magic2Input.KeyboardScanCode1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic2", "KeyboardScanCode2", Magic2Input.KeyboardScanCode2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic2", "KeyboardScanCode3", Magic2Input.KeyboardScanCode3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic2", "GamepadButton1", Magic2Input.GamepadButton1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic2", "GamepadButton2", Magic2Input.GamepadButton2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic2", "GamepadButton3", Magic2Input.GamepadButton3.load(std::memory_order_relaxed));
+        ini.SetLongValue("General", "SlotCount", static_cast<long>(n));
 
-        ini.SetLongValue("Magic3", "KeyboardScanCode1", Magic3Input.KeyboardScanCode1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic3", "KeyboardScanCode2", Magic3Input.KeyboardScanCode2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic3", "KeyboardScanCode3", Magic3Input.KeyboardScanCode3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic3", "GamepadButton1", Magic3Input.GamepadButton1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic3", "GamepadButton2", Magic3Input.GamepadButton2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic3", "GamepadButton3", Magic3Input.GamepadButton3.load(std::memory_order_relaxed));
-
-        ini.SetLongValue("Magic4", "KeyboardScanCode1", Magic4Input.KeyboardScanCode1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic4", "KeyboardScanCode2", Magic4Input.KeyboardScanCode2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic4", "KeyboardScanCode3", Magic4Input.KeyboardScanCode3.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic4", "GamepadButton1", Magic4Input.GamepadButton1.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic4", "GamepadButton2", Magic4Input.GamepadButton2.load(std::memory_order_relaxed));
-        ini.SetLongValue("Magic4", "GamepadButton3", Magic4Input.GamepadButton3.load(std::memory_order_relaxed));
+        for (std::uint32_t i = 0; i < n; ++i) {
+            const auto sec = std::format("Magic{}", i + 1);
+            _saveInput(ini, sec.c_str(), slotInput[i]);
+        }
 
         ini.SetBoolValue("Patches", "SkipEquipAnimationPatch", skipEquipAnimationPatch);
         ini.SetBoolValue("Patches", "RequireExclusiveHotkeyPatch", requireExclusiveHotkeyPatch);

--- a/src/MagicConfig.h
+++ b/src/MagicConfig.h
@@ -1,9 +1,12 @@
 #pragma once
+#include <array>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <filesystem>
 
 namespace IntegratedMagic {
+
     struct InputConfig {
         std::atomic<int> KeyboardScanCode1{-1};
         std::atomic<int> KeyboardScanCode2{-1};
@@ -15,21 +18,23 @@ namespace IntegratedMagic {
     };
 
     struct MagicConfig {
-        std::atomic<std::uint32_t> slotSpellFormID1{0};
-        std::atomic<std::uint32_t> slotSpellFormID2{0};
-        std::atomic<std::uint32_t> slotSpellFormID3{0};
-        std::atomic<std::uint32_t> slotSpellFormID4{0};
+        static constexpr std::uint32_t kMaxSlots = 64;
 
-        InputConfig Magic1Input;
-        InputConfig Magic2Input;
-        InputConfig Magic3Input;
-        InputConfig Magic4Input;
+        std::atomic<std::uint32_t> slotCount{4};
+
+        std::array<std::atomic<std::uint32_t>, kMaxSlots> slotSpellFormID;
+
+        std::array<InputConfig, kMaxSlots> slotInput;
 
         bool skipEquipAnimationPatch = false;
         bool requireExclusiveHotkeyPatch = false;
 
+        MagicConfig();
+
         void Load();
         void Save() const;
+
+        std::uint32_t SlotCount() const noexcept;
 
     private:
         static std::filesystem::path IniPath();

--- a/src/MagicSlots.cpp
+++ b/src/MagicSlots.cpp
@@ -5,44 +5,43 @@
 #include "SpellSettingsDB.h"
 
 namespace IntegratedMagic::MagicSlots {
-    static std::atomic<std::uint32_t>& SlotRef(IntegratedMagic::MagicConfig& cfg, int slot) {
-        switch (slot) {
-            case 0:
-                return cfg.slotSpellFormID1;
-            case 1:
-                return cfg.slotSpellFormID2;
-            case 2:
-                return cfg.slotSpellFormID3;
-            case 3:
-                return cfg.slotSpellFormID4;
-            default:
-                return cfg.slotSpellFormID1;
+    std::uint32_t GetSlotCount() { return IntegratedMagic::GetMagicConfig().SlotCount(); }
+
+    bool IsValidSlot(int slot) {
+        if (slot < 0) {
+            return false;
         }
+        const auto n = IntegratedMagic::GetMagicConfig().SlotCount();
+        return static_cast<std::uint32_t>(slot) < n;
     }
 
     std::uint32_t GetSlotSpell(int slot) {
-        if (slot < 0 || slot > 3) {
-            return 0;
-        }
         auto& cfg = IntegratedMagic::GetMagicConfig();
-        return SlotRef(cfg, slot).load(std::memory_order_relaxed);
+
+        if (const auto n = cfg.SlotCount(); slot < 0 || static_cast<std::uint32_t>(slot) >= n) {
+            return 0u;
+        }
+
+        return cfg.slotSpellFormID[static_cast<std::size_t>(slot)].load(std::memory_order_relaxed);
     }
 
     void SetSlotSpell(int slot, std::uint32_t spellFormID, bool saveNow) {
-        if (slot < 0 || slot > 3) {
+        auto& cfg = IntegratedMagic::GetMagicConfig();
+
+        if (const auto n = cfg.SlotCount(); slot < 0 || static_cast<std::uint32_t>(slot) >= n) {
             return;
         }
 
-        auto& cfg = IntegratedMagic::GetMagicConfig();
-        SlotRef(cfg, slot).store(spellFormID, std::memory_order_relaxed);
+        cfg.slotSpellFormID[static_cast<std::size_t>(slot)].store(spellFormID, std::memory_order_relaxed);
 
-        if (spellFormID != 0) {
+        if (spellFormID != 0u) {
             (void)IntegratedMagic::SpellSettingsDB::Get().GetOrCreate(spellFormID);
         }
 
         if (saveNow) {
             cfg.Save();
-            if (const bool dirty = IntegratedMagic::SpellSettingsDB::Get().IsDirty(); dirty) {
+
+            if (IntegratedMagic::SpellSettingsDB::Get().IsDirty()) {
                 IntegratedMagic::SpellSettingsDB::Get().Save();
                 IntegratedMagic::SpellSettingsDB::Get().ClearDirty();
             }

--- a/src/MagicSlots.h
+++ b/src/MagicSlots.h
@@ -2,6 +2,9 @@
 #include <cstdint>
 
 namespace IntegratedMagic::MagicSlots {
+    std::uint32_t GetSlotCount();
+    bool IsValidSlot(int slot);
+
     std::uint32_t GetSlotSpell(int slot);
     void SetSlotSpell(int slot, std::uint32_t spellFormID, bool saveNow = true);
 }

--- a/src/MagicState.cpp
+++ b/src/MagicState.cpp
@@ -322,7 +322,7 @@ namespace IntegratedMagic {
             return;
         }
 
-        if (slot < 0 || slot >= 4) {
+        if (!IntegratedMagic::MagicSlots::IsValidSlot(slot)) {
             return;
         }
 
@@ -429,7 +429,7 @@ namespace IntegratedMagic {
     }
 
     void MagicState::HoldDown(int slot) {
-        if (slot < 0 || slot >= 4) {
+        if (!IntegratedMagic::MagicSlots::IsValidSlot(slot)) {
             return;
         }
 
@@ -587,7 +587,7 @@ namespace IntegratedMagic {
     }
 
     void MagicState::EnterAutomatic(int slot) {
-        if (slot < 0 || slot >= 4) {
+        if (!IntegratedMagic::MagicSlots::IsValidSlot(slot)) {
             return;
         }
 
@@ -621,7 +621,7 @@ namespace IntegratedMagic {
             return;
         }
 
-        if (slot < 0 || slot >= 4) {
+        if (!IntegratedMagic::MagicSlots::IsValidSlot(slot)) {
             return;
         }
 

--- a/src/SaveSpellDB.h
+++ b/src/SaveSpellDB.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <array>
 #include <cstdint>
 #include <filesystem>
 #include <functional>
@@ -7,6 +6,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 namespace IntegratedMagic {
     struct TransparentSaveKeyHash {
@@ -18,7 +18,7 @@ namespace IntegratedMagic {
     };
 
     struct SaveSpellSlots {
-        std::array<std::uint32_t, 4> slotSpellFormID{{0, 0, 0, 0}};
+        std::vector<std::uint32_t> slotSpellFormID;
     };
 
     class SaveSpellDB {

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -30,21 +30,25 @@ namespace {
         auto const& cfg = IntegratedMagic::GetMagicConfig();
 
         IntegratedMagic::SaveSpellSlots s{};
+        const auto n = cfg.SlotCount();
 
-        s.slotSpellFormID[0] = cfg.slotSpellFormID1.load(std::memory_order_relaxed);
-        s.slotSpellFormID[1] = cfg.slotSpellFormID2.load(std::memory_order_relaxed);
-        s.slotSpellFormID[2] = cfg.slotSpellFormID3.load(std::memory_order_relaxed);
-        s.slotSpellFormID[3] = cfg.slotSpellFormID4.load(std::memory_order_relaxed);
+        s.slotSpellFormID.resize(n, 0u);
+
+        for (std::uint32_t i = 0; i < n; ++i) {
+            s.slotSpellFormID[i] = cfg.slotSpellFormID[static_cast<std::size_t>(i)].load(std::memory_order_relaxed);
+        }
+
         return s;
     }
 
     void ApplySlotsToConfig(const IntegratedMagic::SaveSpellSlots& s) {
         auto& cfg = IntegratedMagic::GetMagicConfig();
+        const auto n = cfg.SlotCount();
 
-        cfg.slotSpellFormID1.store(s.slotSpellFormID[0], std::memory_order_relaxed);
-        cfg.slotSpellFormID2.store(s.slotSpellFormID[1], std::memory_order_relaxed);
-        cfg.slotSpellFormID3.store(s.slotSpellFormID[2], std::memory_order_relaxed);
-        cfg.slotSpellFormID4.store(s.slotSpellFormID[3], std::memory_order_relaxed);
+        for (std::uint32_t i = 0; i < n; ++i) {
+            const std::uint32_t v = (i < s.slotSpellFormID.size()) ? s.slotSpellFormID[i] : 0u;
+            cfg.slotSpellFormID[static_cast<std::size_t>(i)].store(v, std::memory_order_relaxed);
+        }
     }
 
     std::string ExtractKey(std::string s) {


### PR DESCRIPTION
O sistema inteiro foi refatorado para funcionar com N slots de magia ao invés dos 4 que estavam hardcoded antes

## Summary by Sourcery

Support a configurable number of magic slots instead of a hardcoded set of four, propagating dynamic slot handling through input, config, UI, save/load, and gameplay logic.

New Features:
- Allow configuring the number of magic slots via ini and in-game UI up to a defined maximum.
- Persist per-slot spells and hotkeys for an arbitrary number of magic slots in both config and save JSON files.

Enhancements:
- Refactor magic input handling to operate on a dynamic slot count using 64-bit bitmasks instead of a fixed 4-slot byte mask.
- Generalize spell slot accessors and validation to work with a variable number of slots.
- Increase supported input scan code range for keyboard/gamepad hotkeys.