### PR TITLE
Cast Guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ target_precompile_headers(${PROJECT_NAME}
     src/State/State.h
     src/State/Action.h
     src/State/AnimListener.h
+    src/State/CastGuardEvents.h
 ) 
 
 set_source_files_properties(

--- a/src/State/AnimListener.cpp
+++ b/src/State/AnimListener.cpp
@@ -33,4 +33,7 @@ void AnimListener::HandleAnimEvent(const RE::BSAnimationGraphEvent* ev,
     if (tag == "shoutStop"sv) {
         state.OnShoutStop();
     }
+    if (tag == "blockStart"sv || tag == "BashExit"sv) {
+        state.ForceExit();
+    }
 }

--- a/src/State/CastGuardEvents.h
+++ b/src/State/CastGuardEvents.h
@@ -1,0 +1,66 @@
+#pragma once
+#include "State.h"
+#include "PCH.h"
+
+class CastGuardEvents :
+    public RE::BSTEventSink<RE::TESDeathEvent>,
+    public RE::BSTEventSink<RE::TESLoadGameEvent>,
+    public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+{
+public:
+    static CastGuardEvents& Get() {
+        static CastGuardEvents instance;
+        return instance;
+    }
+
+    void Register() {
+        auto* holder = RE::ScriptEventSourceHolder::GetSingleton();
+        if (!holder) return;
+        holder->AddEventSink<RE::TESDeathEvent>(this);
+        holder->AddEventSink<RE::TESLoadGameEvent>(this);
+
+        if (auto* ui = RE::UI::GetSingleton()) {
+            ui->AddEventSink<RE::MenuOpenCloseEvent>(this);
+        }
+    }
+
+protected:
+    RE::BSEventNotifyControl ProcessEvent(
+        const RE::TESDeathEvent* ev,
+        RE::BSTEventSource<RE::TESDeathEvent>*) override
+    {
+        auto* pc = RE::PlayerCharacter::GetSingleton();
+        if (ev && ev->actorDying && ev->actorDying.get() == pc) {
+            IntegratedMagic::MagicState::Get().ForceExit();
+        }
+        return RE::BSEventNotifyControl::kContinue;
+    }
+
+    RE::BSEventNotifyControl ProcessEvent(
+        const RE::TESLoadGameEvent*,
+        RE::BSTEventSource<RE::TESLoadGameEvent>*) override
+    {
+        IntegratedMagic::MagicState::Get().ForceExit();
+        return RE::BSEventNotifyControl::kContinue;
+    }
+
+    RE::BSEventNotifyControl ProcessEvent(
+        const RE::MenuOpenCloseEvent* ev,
+        RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override
+    {
+        static constexpr std::array kInterruptMenus = {
+            "ContainerMenu"sv, "InventoryMenu"sv,
+            "MagicMenu"sv,     "MapMenu"sv,
+            "Journal Menu"sv,  "Dialogue Menu"sv,
+        };
+        if (ev && ev->opening) {
+            for (auto m : kInterruptMenus) {
+                if (ev->menuName == m) {
+                    IntegratedMagic::MagicState::Get().ForceExit();
+                    break;
+                }
+            }
+        }
+        return RE::BSEventNotifyControl::kContinue;
+    }
+};

--- a/src/State/State.cpp
+++ b/src/State/State.cpp
@@ -96,6 +96,31 @@ namespace IntegratedMagic {
     }
 
     namespace {
+        using WS = RE::WEAPON_STATE;
+        using KS = RE::KNOCK_STATE_ENUM;
+
+        bool PlayerIsDead(RE::PlayerCharacter* pc) { return pc->IsDead(); }
+
+        bool PlayerIsKnockedOrStaggered(RE::PlayerCharacter* pc) {
+            auto ks = pc->AsActorState()->GetKnockState();
+            return ks != KS::kNormal && ks != KS::kQueued;
+        }
+
+        bool PlayerIsBlocking(RE::PlayerCharacter* pc) { return pc->IsBlocking(); }
+
+        bool PlayerIsSheathingOrSheathed(RE::PlayerCharacter* pc) {
+            auto ws = pc->AsActorState()->GetWeaponState();
+            return ws == WS::kSheathing || ws == WS::kSheathed || ws == WS::kWantToSheathe;
+        }
+
+        bool CasterSpellMismatch(RE::ActorMagicCaster* caster, RE::SpellItem* expected) {
+            if (!caster || !expected) return false;
+            auto* cur = caster->currentSpell ? caster->currentSpell->As<RE::SpellItem>() : nullptr;
+
+            if (!cur) return false;
+            return cur != expected;
+        }
+
         inline RE::PlayerCharacter* GetPlayer() { return RE::PlayerCharacter::GetSingleton(); }
 
         RE::ExtraDataList* GetWornExtraForHand(RE::InventoryEntryData const* entry, bool leftHand) {
@@ -391,6 +416,7 @@ namespace IntegratedMagic {
         _shoutIsPower = false;
         _powerAutoSecs = 0.f;
         _shoutWaitingStopEvent = false;
+        _activeTimeoutSecs = 0.f;
     }
 
     void MagicState::CaptureSnapshot(RE::PlayerCharacter const* player) {
@@ -944,10 +970,22 @@ namespace IntegratedMagic {
         PumpAutomaticHand(Left);
         PumpAutomaticHand(Right);
 
-        if (_active && _modeShoutID != 0 && _shoutIsPower && _shoutHeld && !_shoutFinished) {
+        if (!_active) return;
+        if (ShouldForceInterrupt()) {
+            ForceExit();
+            return;
+        }
+
+        _activeTimeoutSecs += dt;
+        if (_activeTimeoutSecs > kMaxActiveTimeoutSecs) {
+            ForceExit();
+            return;
+        }
+
+        if (_modeShoutID != 0 && _shoutIsPower && _shoutHeld && !_shoutFinished) {
             const auto ss = SpellSettingsDB::Get().GetOrCreate(_modeShoutID);
             if (ss.mode == IntegratedMagic::ActivationMode::Automatic) {
-                constexpr float kPowerAutoDuration = 1.0f;
+                constexpr float kPowerAutoDuration = 0.5f;
                 _powerAutoSecs += (dt > 0.f ? dt : 0.f);
                 if (_powerAutoSecs >= kPowerAutoDuration) {
                     StopShoutPress();
@@ -1327,8 +1365,12 @@ namespace IntegratedMagic {
         if (!_active || _modeShoutID == 0 || _shoutFinished) return;
         if (_shoutIsPower) return;
         const auto ss = SpellSettingsDB::Get().GetOrCreate(_modeShoutID);
+        const bool isHold = (ss.mode == IntegratedMagic::ActivationMode::Hold);
         const bool isAutomatic = (ss.mode == IntegratedMagic::ActivationMode::Automatic);
-        if (isAutomatic || _shoutWaitingStopEvent) {
+        if (isAutomatic || _shoutWaitingStopEvent || isHold) {
+            if (isHold && !_shoutWaitingStopEvent) {
+                StopShoutPress();
+            }
             _shoutWaitingStopEvent = false;
             _shoutFinished = true;
             TryFinalizeExit();
@@ -1374,5 +1416,65 @@ namespace IntegratedMagic {
         using enum IntegratedMagic::Slots::Hand;
         pumpOne(Left);
         pumpOne(Right);
+    }
+
+    bool MagicState::ShouldForceInterrupt() const {
+        if (!_active) return false;
+        auto* pc = GetPlayer();
+        if (!pc) return true;
+
+        if (PlayerIsDead(pc)) return true;
+        if (PlayerIsKnockedOrStaggered(pc)) return true;
+        if (PlayerIsBlocking(pc)) return true;
+        if (PlayerIsSheathingOrSheathed(pc)) return true;
+
+        using Hand = Slots::Hand;
+        if (_modeSpellRight) {
+            auto* caster = MagicAction::GetCaster(pc, RE::MagicSystem::CastingSource::kRightHand);
+            if (CasterSpellMismatch(caster, _modeSpellRight)) return true;
+        }
+        if (_modeSpellLeft) {
+            auto* caster = MagicAction::GetCaster(pc, RE::MagicSystem::CastingSource::kLeftHand);
+            if (CasterSpellMismatch(caster, _modeSpellLeft)) return true;
+        }
+
+        return false;
+    }
+
+    void MagicState::ForceExit() {
+        if (!_active) return;
+
+        auto* pc = GetPlayer();
+
+        StopAllAutoAttack();
+        CancelAllDelayedStarts();
+
+        _left = {};
+        _right = {};
+
+        if (pc && !pc->IsDead() && _snap.valid) {
+            RestoreSnapshot(pc);
+        }
+
+        _snap = {};
+        _active = false;
+        _activeSlot = -1;
+        _modeSpellLeft = nullptr;
+        _modeSpellRight = nullptr;
+        _dirtyLeft = false;
+        _dirtyRight = false;
+        _modeShoutID = 0;
+        _shoutFinished = false;
+        _shoutHeld = false;
+        _activeTimeoutSecs = 0.f;
+        _pendingRestore = false;
+        _pendingSkipFirstCastStop = false;
+        _firstInterrupt = 0;
+    }
+
+    void MagicState::ForceExitNoRestore() {
+        if (!_active) return;
+        _snap = {};
+        ForceExit();
     }
 }

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -99,6 +99,8 @@ namespace IntegratedMagic {
         void PumpAutomatic(float dt);
         void OnBeginCast(IntegratedMagic::Slots::Hand hand);
         void OnShoutStop();
+        void ForceExit();
+        void ForceExitNoRestore();
         const HandMode& LeftMode() const noexcept { return _left; }
         const HandMode& RightMode() const noexcept { return _right; }
 
@@ -179,6 +181,7 @@ namespace IntegratedMagic {
         void SetModeSpellsFromHand(IntegratedMagic::Slots::Hand hand, RE::SpellItem* spell);
         void StartShoutPress();
         void StopShoutPress();
+        bool ShouldForceInterrupt() const;
         static inline bool IsLeft(IntegratedMagic::Slots::Hand h) { return h == IntegratedMagic::Slots::Hand::Left; }
         void MarkDirty(IntegratedMagic::Slots::Hand h) {
             if (IsLeft(h))
@@ -217,6 +220,8 @@ namespace IntegratedMagic {
         bool _shoutIsPower{false};
         float _powerAutoSecs{0.f};
         bool _shoutWaitingStopEvent{false};
+        float _activeTimeoutSecs{0.f};
+        static constexpr float kMaxActiveTimeoutSecs = 30.f;
     };
 
     template <class Fn>

--- a/src/UI/MENU_IntegratedMagic.cpp
+++ b/src/UI/MENU_IntegratedMagic.cpp
@@ -88,7 +88,7 @@ namespace {
         const auto idx = static_cast<std::size_t>(slot);
         cfg.slotSpellFormIDLeft[idx].store(0u, std::memory_order_relaxed);
         cfg.slotSpellFormIDRight[idx].store(0u, std::memory_order_relaxed);
-        cfg.slotShoutFormID[idx].store(0u, std::memory_order_relaxed);  // NOVO
+        cfg.slotShoutFormID[idx].store(0u, std::memory_order_relaxed);
         auto& icfg = cfg.slotInput[idx];
         icfg.KeyboardScanCode1.store(-1, std::memory_order_relaxed);
         icfg.KeyboardScanCode2.store(-1, std::memory_order_relaxed);

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -7,6 +7,7 @@
 #include "UI/MENU_IntegratedMagic.h"
 #include "UI/Strings.h"
 #include "UI/StyleConfig.h"
+#include "State/CastGuardEvents.h"
 
 #ifndef DLLEXPORT
     #include "REL/Relocation.h"
@@ -118,6 +119,7 @@ namespace {
                 IntegratedMagic::TextureManager::Init();
                 Input::OnConfigChanged();
                 IntegratedMagic::Hooks::Install_Hooks();
+                CastGuardEvents::Get().Register();
                 break;
             }
             case SKSE::MessagingInterface::kPostLoadGame: {


### PR DESCRIPTION
… cast foi interrompido para limpar o estado

## Summary by Sourcery

Add safeguards to automatically interrupt and clean up active casting state when the player’s conditions or context become invalid.

New Features:
- Introduce CastGuardEvents to listen to death, load game, and menu events and forcefully exit the magic state when appropriate.

Bug Fixes:
- Ensure active casting state is forcefully interrupted when the player dies, is knocked down, blocks, sheathes weapons, or changes away from the expected spell in either hand.
- Prevent lingering active casting sessions by enforcing a maximum active duration before automatic exit.

Enhancements:
- Expose ForceExit and ForceExitNoRestore helpers on MagicState to centralize casting teardown and state restoration logic.
- Trigger forced casting exit on relevant animation events such as block start and bash exit.
- Reduce automatic power shout hold duration to make automatic activations respond more quickly.
- Treat hold-mode shouts as requiring a stop event and finalize them consistently with automatic shouts.

Build:
- Register the new CastGuardEvents handler during plugin initialization and include its header in the precompiled headers list.