### PR TITLE
feat(patch): :sparkles: added press both at same time patch

### DIFF
--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -97,9 +97,10 @@ namespace IntegratedMagic {
         skipEquipAnimationPatch = _getBool(ini, "Patches", "SkipEquipAnimationPatch", false);
         skipEquipAnimationOnReturnPatch = _getBool(ini, "Patches", "SkipEquipAnimationOnReturn", false);
         requireExclusiveHotkeyPatch = _getBool(ini, "Patches", "RequireExclusiveHotkeyPatch", false);
+        pressBothAtSamePatch = _getBool(ini, "Patches", "PressBothAtSamePatch", false);
 
         modifierKeyboardPosition = std::clamp(_getInt(ini, "Modifier", "KeyboardPosition", 0), 0, 3);
-        modifierGamepadPosition  = std::clamp(_getInt(ini, "Modifier", "GamepadPosition",  0), 0, 3);
+        modifierGamepadPosition = std::clamp(_getInt(ini, "Modifier", "GamepadPosition", 0), 0, 3);
 
         using FieldPtr = std::atomic<int> InputConfig::*;
 
@@ -107,21 +108,26 @@ namespace IntegratedMagic {
             if (pos <= 0) return;
             FieldPtr field = nullptr;
             if (isKb) {
-                if (pos == 1) field = &InputConfig::KeyboardScanCode1;
-                else if (pos == 2) field = &InputConfig::KeyboardScanCode2;
-                else field = &InputConfig::KeyboardScanCode3;
+                if (pos == 1)
+                    field = &InputConfig::KeyboardScanCode1;
+                else if (pos == 2)
+                    field = &InputConfig::KeyboardScanCode2;
+                else
+                    field = &InputConfig::KeyboardScanCode3;
             } else {
-                if (pos == 1) field = &InputConfig::GamepadButton1;
-                else if (pos == 2) field = &InputConfig::GamepadButton2;
-                else field = &InputConfig::GamepadButton3;
+                if (pos == 1)
+                    field = &InputConfig::GamepadButton1;
+                else if (pos == 2)
+                    field = &InputConfig::GamepadButton2;
+                else
+                    field = &InputConfig::GamepadButton3;
             }
             const int canonical = (slotInput[0].*field).load(std::memory_order_relaxed);
-            for (std::uint32_t i = 1; i < n; ++i)
-                (slotInput[i].*field).store(canonical, std::memory_order_relaxed);
+            for (std::uint32_t i = 1; i < n; ++i) (slotInput[i].*field).store(canonical, std::memory_order_relaxed);
         };
 
         propagateModifier(modifierKeyboardPosition, true);
-        propagateModifier(modifierGamepadPosition,  false);
+        propagateModifier(modifierGamepadPosition, false);
     }
 
     void MagicConfig::Save() const {
@@ -140,8 +146,9 @@ namespace IntegratedMagic {
         ini.SetBoolValue("Patches", "SkipEquipAnimationPatch", skipEquipAnimationPatch);
         ini.SetBoolValue("Patches", "SkipEquipAnimationOnReturn", skipEquipAnimationOnReturnPatch);
         ini.SetBoolValue("Patches", "RequireExclusiveHotkeyPatch", requireExclusiveHotkeyPatch);
+        ini.SetBoolValue("Patches", "PressBothAtSamePatch", pressBothAtSamePatch);
         ini.SetLongValue("Modifier", "KeyboardPosition", modifierKeyboardPosition);
-        ini.SetLongValue("Modifier", "GamepadPosition",  modifierGamepadPosition);
+        ini.SetLongValue("Modifier", "GamepadPosition", modifierGamepadPosition);
         std::error_code ec;
         std::filesystem::create_directories(path.parent_path(), ec);
         ini.SaveFile(path.string().c_str());

--- a/src/Config/Config.h
+++ b/src/Config/Config.h
@@ -28,6 +28,7 @@ namespace IntegratedMagic {
         bool skipEquipAnimationPatch = false;
         bool skipEquipAnimationOnReturnPatch = false;
         bool requireExclusiveHotkeyPatch = false;
+        bool pressBothAtSamePatch = false;
 
         int modifierKeyboardPosition{0};
         int modifierGamepadPosition{0};

--- a/src/Input/Input.cpp
+++ b/src/Input/Input.cpp
@@ -19,6 +19,7 @@ namespace {
     constexpr int kMaxSlots = static_cast<int>(IntegratedMagic::MagicConfig::kMaxSlots);
     constexpr int kMaxCode = 400;
     constexpr float kExclusiveConfirmDelaySec = 0.10f;
+    constexpr float kSimultaneousWindowSec = 0.20f;
     constexpr int kDIK_W = 0x11;
     constexpr int kDIK_A = 0x1E;
     constexpr int kDIK_S = 0x1F;
@@ -38,6 +39,10 @@ namespace {
     std::array<bool, kMaxSlots> g_slotFullComboSeen{};
     std::array<bool, kMaxSlots> g_prevRawGpDown{};
     std::array<float, kMaxSlots> g_exclusivePendingTimer{};
+
+    std::array<bool, kMaxSlots> g_prevAnyKeyDown{};
+    std::array<bool, kMaxSlots> g_simWindowActive{};
+    std::array<float, kMaxSlots> g_simWindowRemaining{};
 
     enum class PendingSrc : std::uint8_t { None = 0, Kb = 1, Gp = 2 };
     std::array<PendingSrc, kMaxSlots> g_exclusivePendingSrc{};
@@ -199,6 +204,9 @@ namespace {
             g_slotFullComboSeen[s] = false;
             g_prevRawKbDown[s] = false;
             g_prevRawGpDown[s] = false;
+            g_prevAnyKeyDown[s] = false;
+            g_simWindowActive[s] = false;
+            g_simWindowRemaining[s] = 0.f;
             DiscardExclusivePending(s);
         }
         g_pressedMask.store(0uLL, std::memory_order_relaxed);
@@ -238,6 +246,9 @@ namespace {
             const auto s = static_cast<std::size_t>(slot);
             g_prevRawKbDown[s] = false;
             g_prevRawGpDown[s] = false;
+            g_prevAnyKeyDown[s] = false;
+            g_simWindowActive[s] = false;
+            g_simWindowRemaining[s] = 0.f;
             DiscardExclusivePending(s);
             g_slotDown[s].store(false, std::memory_order_relaxed);
             g_slotWasAccepted[s] = false;
@@ -287,6 +298,33 @@ namespace {
         g_prevRawKbDown[s] = kbNow;
         g_prevRawGpDown[s] = gpNow;
 
+        const bool simPatch = IntegratedMagic::GetMagicConfig().pressBothAtSamePatch && isMulti;
+        {
+            const bool anyComboNow = AnyComboKeyDown(hk.kb, g_kbDown) || AnyComboKeyDown(hk.gp, g_gpDown);
+            const bool prevAnyDown = g_prevAnyKeyDown[s];
+            g_prevAnyKeyDown[s] = anyComboNow;
+
+            if (!anyComboNow) {
+                g_simWindowActive[s] = false;
+                g_simWindowRemaining[s] = 0.f;
+            } else if (anyComboNow && !prevAnyDown) {
+                g_simWindowActive[s] = true;
+                g_simWindowRemaining[s] = kSimultaneousWindowSec;
+#ifdef DEBUG
+                spdlog::info("[Input] ComputeAcceptedExclusive: slot={} sim-window OPENED ({:.2f}s)", slot,
+                             kSimultaneousWindowSec);
+#endif
+            } else if (g_simWindowActive[s]) {
+                g_simWindowRemaining[s] -= dt;
+                if (g_simWindowRemaining[s] <= 0.f) {
+                    g_simWindowActive[s] = false;
+#ifdef DEBUG
+                    spdlog::info("[Input] ComputeAcceptedExclusive: slot={} sim-window EXPIRED", slot);
+#endif
+                }
+            }
+        }
+
         if (prevAccepted) {
             DiscardExclusivePending(s);
             return rawNow;
@@ -309,6 +347,15 @@ namespace {
 
             if (isMulti) {
                 if (stillDown && !g_slotFullComboSeen[s]) {
+                    if (simPatch && !g_simWindowActive[s]) {
+#ifdef DEBUG
+                        spdlog::info(
+                            "[Input] ComputeAcceptedExclusive: slot={} full combo REJECTED by sim-window (expired)",
+                            slot);
+#endif
+                        ClearExclusivePending(s, ClearReason::Cancelled);
+                        return false;
+                    }
                     g_slotFullComboSeen[s] = true;
                     g_exclusivePendingTimer[s] = kExclusiveConfirmDelaySec;
 #ifdef DEBUG
@@ -390,6 +437,14 @@ namespace {
         const bool gpEdge = gpNow && !gpPrev;
 
         if (kbEdge && ComboExclusiveNow(hk.kb, g_kbDown, IsAllowedExtra_Keyboard_MoveOrCamera)) {
+            if (simPatch && !g_simWindowActive[s]) {
+#ifdef DEBUG
+                spdlog::info(
+                    "[Input] ComputeAcceptedExclusive: slot={} KB edge REJECTED by sim-window (expired/inactive)",
+                    slot);
+#endif
+                return false;
+            }
 #ifdef DEBUG
             spdlog::info(
                 "[Input] ComputeAcceptedExclusive: slot={} KB edge detected, starting exclusive pending (isMulti={})",
@@ -401,6 +456,14 @@ namespace {
             return false;
         }
         if (gpEdge && ComboExclusiveNow(hk.gp, g_gpDown, IsAllowedExtra_Gamepad_MoveOrCamera)) {
+            if (simPatch && !g_simWindowActive[s]) {
+#ifdef DEBUG
+                spdlog::info(
+                    "[Input] ComputeAcceptedExclusive: slot={} GP edge REJECTED by sim-window (expired/inactive)",
+                    slot);
+#endif
+                return false;
+            }
 #ifdef DEBUG
             spdlog::info(
                 "[Input] ComputeAcceptedExclusive: slot={} GP edge detected, starting exclusive pending (isMulti={})",

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -682,6 +682,21 @@ namespace {
                                                     "during combat or movement.")
                           .c_str());
         }
+
+        if (bool v4 = cfg.pressBothAtSamePatch; ImGui::Checkbox(
+                IntegratedMagic::Strings::Get("Item_PressBothAtSame", "Press both at the same time").c_str(), &v4)) {
+            cfg.pressBothAtSamePatch = v4;
+            dirty = true;
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "%s", IntegratedMagic::Strings::Get("Tooltip_PressBothAtSame",
+                                                    "When enabled, all keys in a combo must be pressed within\n"
+                                                    "0.2 seconds of each other.\n"
+                                                    "Holding one key and pressing the other later will not activate\n"
+                                                    "the slot.")
+                          .c_str());
+        }
     }
 }
 


### PR DESCRIPTION
New patch that allows you to choose between keys needing to be pressed together at the same time or simply needing to be pressed together.

## Summary by Sourcery

Add an optional patch that requires multi-key hotkey combos to be pressed within a short time window to activate.

New Features:
- Introduce a configurable "press both at the same time" patch that enforces a 0.2 second simultaneity window for multi-key hotkey combos.

Enhancements:
- Track per-slot combo key state and timing to support simultaneity checks in the input system.
- Expose the new simultaneity patch as a toggleable option in the in-game menu and persist it in the configuration file.