### PR TITLE
fix(spell): :bug: Bug where the spell would get stuck in hand

### DIFF
--- a/src/State/AnimListener.cpp
+++ b/src/State/AnimListener.cpp
@@ -62,6 +62,15 @@ void AnimListener::HandleAnimEvent(const RE::BSAnimationGraphEvent* ev,
     if (tag == "tailMTIdle"sv || tag == "IdleStop"sv) {
         if (state.IsWaitingSheatheRestore()) {
             state.NotifySheatheComplete();
+#ifdef DEBUG
+            spdlog::info("[AnimListener] >> {} -> NotifySheatheComplete!");
+#endif
         }
+    }
+    if (tag == "MRh_SpellFire_Event"sv) {
+        state.OnSpellFired(Hand::Right);
+    }
+    if (tag == "MLh_SpellFire_Event"sv) {
+        state.OnSpellFired(Hand::Left);
     }
 }

--- a/src/State/MagicStatePump.cpp
+++ b/src/State/MagicStatePump.cpp
@@ -166,6 +166,9 @@ namespace IntegratedMagic {
                 --_session.dualCastSkipCastStops;
                 return;
             }
+            if (!_left.chargeComplete && !_right.chargeComplete) {
+                return;
+            }
             FinishHand(Left);
             FinishHand(Right);
             _session.isDualCasting = false;
@@ -466,6 +469,21 @@ namespace IntegratedMagic {
                 _shout.finished = true;
                 TryFinalizeExit();
             }
+        }
+    }
+
+    void MagicState::OnSpellFired(Slots::Hand hand) {
+        if (!_session.active) return;
+        auto& hm = ModeFor(hand);
+        if (hm.autoActive && !hm.finished && hm.chargeComplete) {
+            if (_session.isDualCasting) {
+                FinishHand(Slots::Hand::Left);
+                FinishHand(Slots::Hand::Right);
+                _session.isDualCasting = false;
+            } else {
+                FinishHand(hand);
+            }
+            TryFinalizeExit();
         }
     }
 }

--- a/src/State/MagicStateSlot.cpp
+++ b/src/State/MagicStateSlot.cpp
@@ -62,17 +62,22 @@ namespace IntegratedMagic {
 #ifdef DEBUG
         const char* handStr = IsLeft(hand) ? "Left" : "Right";
 #endif
+        const auto& cfg = IntegratedMagic::GetMagicConfig();
         switch (ss.mode) {
             case Hold:
                 hm.holdActive = true;
                 if (hm.wantAutoAttack) {
                     hm.waitingAutoAfterEquip = true;
                     hm.waitingEnableBumperSecs = 0.f;
-                    hm.waitingBeginCast = false;
+                    hm.waitingBeginCast = true;
                     hm.beginCastWaitSecs = 0.f;
                     hm.beginCastRetries = 0;
                     _session.attackEnabled = false;
-                    _cast.castStopsToSkip = _session.wasHandsDown ? 2 : 1;
+                    if (cfg.skipEquipAnimationPatch) {
+                        _cast.castStopsToSkip = _session.wasHandsDown ? 2 : 1;
+                    } else {
+                        _cast.castStopsToSkip = 0;
+                    }
                 }
 #ifdef DEBUG
                 spdlog::info(
@@ -81,18 +86,21 @@ namespace IntegratedMagic {
                     handStr, hm.wantAutoAttack, hm.waitingAutoAfterEquip, _cast.castStopsToSkip);
 #endif
                 break;
-
             case Automatic:
                 hm.autoActive = true;
                 hm.waitingChargeComplete = true;
                 hm.waitingAutoAfterEquip = true;
                 hm.wantAutoAttack = true;
                 hm.waitingEnableBumperSecs = 0.f;
-                hm.waitingBeginCast = false;
+                hm.waitingBeginCast = true; 
                 hm.beginCastWaitSecs = 0.f;
                 hm.beginCastRetries = 0;
                 _session.attackEnabled = false;
-                _cast.castStopsToSkip = _session.wasHandsDown ? 2 : 1;
+                if (cfg.skipEquipAnimationPatch) {
+                    _cast.castStopsToSkip = _session.wasHandsDown ? 2 : 1;
+                } else {
+                    _cast.castStopsToSkip = 0;
+                }
 #ifdef DEBUG
                 spdlog::info(
                     "[State] EnterHand: hand={} mode=Automatic waitingChargeComplete=true "
@@ -100,7 +108,6 @@ namespace IntegratedMagic {
                     handStr, _cast.castStopsToSkip);
 #endif
                 break;
-
             case Press:
                 hm.pressActive = true;
 #ifdef DEBUG

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -133,6 +133,7 @@ namespace IntegratedMagic {
             return _restore.pendingRestoreAfterSheathe && !_restore.sheatheAnimComplete;
         }
         void NotifySheatheComplete() noexcept { _restore.sheatheAnimComplete = true; }
+        void OnSpellFired(Slots::Hand hand);
         const HandMode& LeftMode() const noexcept { return _left; }
         const HandMode& RightMode() const noexcept { return _right; }
 

--- a/src/UI/HUD.cpp
+++ b/src/UI/HUD.cpp
@@ -648,7 +648,6 @@ namespace IntegratedMagic::HUD {
     }
 
     void DrawHudElement() {
-        if (!g_hudVisible.load(std::memory_order_relaxed)) return;
         if (IsHardBlocked()) return;
         if (Slots::GetSlotCount() == 0) return;
 
@@ -657,9 +656,9 @@ namespace IntegratedMagic::HUD {
         const bool inMagicMenu = ui && ui->IsMenuOpen(magicMenu);
 
         if (inMagicMenu && Input::ConsumeHudToggle()) ToggleDetailPopup();
-
         if (!inMagicMenu && g_popupWindow && g_popupWindow->IsOpen.load()) g_popupWindow->IsOpen = false;
 
+        if (!g_hudVisible.load(std::memory_order_relaxed)) return;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0.f, 0.f});
 


### PR DESCRIPTION
Added a new system for exiting the spell by listening to a new event.

## Summary by Sourcery

Handle spell completion on animation fire events to prevent spells remaining stuck in hand and align HUD visibility checks with other UI conditions.

Bug Fixes:
- Ensure auto-cast spells exit correctly when the spell fire animation event occurs, including during dual casting.
- Prevent dual-cast completion logic from running before either hand has completed charging, avoiding premature state transitions.
- Adjust HUD rendering so visibility checks occur after magic menu and popup window handling to avoid inconsistent HUD state.

Enhancements:
- Respect a configuration flag to optionally skip equip animation cast-stop logic when entering Hold or Automatic modes, changing how auto-attack initiation is gated by begin-cast state.