### PR TITLE
fix(spell): :bug: fixed a bug where the slot remains active when use with low hands

### DIFF
--- a/src/State/MagicStatePump.cpp
+++ b/src/State/MagicStatePump.cpp
@@ -389,9 +389,14 @@ namespace IntegratedMagic {
 
         if (_restore.pendingRestoreAfterSheathe) {
             if (auto* player = GetPlayer()) {
-                const bool giveUp =
-                    player->IsInCombat() || player->AsActorState()->GetWeaponState() == RE::WEAPON_STATE::kWantToDraw;
+                _restore.sheatheWaitSecs += dt > 0.f ? dt : 0.f;
+                const bool timedOut = _restore.sheatheWaitSecs >= RestoreContext::kSheatheWaitTimeoutSec;
+                const bool giveUp = player->IsInCombat() ||
+                                    player->AsActorState()->GetWeaponState() == RE::WEAPON_STATE::kWantToDraw ||
+                                    timedOut;
+                ;
                 if (_restore.sheatheAnimComplete || giveUp) {
+                    _restore.sheatheWaitSecs = 0.f;
 #ifdef DEBUG
                     spdlog::info("[State] PumpAutomatic: pendingRestoreAfterSheathe -> restore (giveUp={})", giveUp);
 #endif

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -64,6 +64,8 @@ namespace IntegratedMagic {
         bool pendingPowerRestore{false};
         float pendingPowerRestoreDelaySecs{0.f};
         static constexpr float kPowerRestoreDelaySec = 0.05f;
+        float sheatheWaitSecs{0.f};
+        static constexpr float kSheatheWaitTimeoutSec = 1.0f;
 
         void ClearDirty() { dirtyLeft = dirtyRight = dirtyShout = false; }
         void ClearPending() { pendingRestore = pendingRestoreAfterSheathe = pendingPowerRestore = false; }


### PR DESCRIPTION
added a timer to avoid draw and sheathe to close

## Summary by Sourcery

Bug Fixes:
- Ensure pending spell restoration after sheathing cancels after a short timeout instead of waiting indefinitely when draw/sheathe states conflict.