### PR TITLE
feat(AutoCast): :sparkles: Added auto cast on press mode

### DIFF
--- a/src/Input/Assign.cpp
+++ b/src/Input/Assign.cpp
@@ -11,6 +11,36 @@ namespace IntegratedMagic::MagicAssign {
 
     namespace {
 
+        static bool IsAssociatedBoundWeaponOfSlot(RE::FormID weaponFormID, int activeSlot) {
+            if (activeSlot < 0 || !weaponFormID) return false;
+
+            const RE::FormID slotIDs[2] = {
+                Slots::GetSlotSpell(activeSlot, Slots::Hand::Left),
+                Slots::GetSlotSpell(activeSlot, Slots::Hand::Right),
+            };
+
+            for (const auto spellID : slotIDs) {
+                if (!spellID) continue;
+                const auto* spell = RE::TESForm::LookupByID<RE::SpellItem>(spellID);
+                if (!spell) continue;
+
+                for (const auto* effect : spell->effects) {
+                    if (!effect || !effect->baseEffect) continue;
+                    const auto* associated = effect->baseEffect->data.associatedForm;
+                    if (associated && associated->GetFormID() == weaponFormID) {
+#ifdef DEBUG
+                        spdlog::info(
+                            "[Assign] IsAssociatedBoundWeaponOfSlot: weaponID={:#010x} matched associatedForm "
+                            "of spell={:#010x} in slot={}",
+                            weaponFormID, spellID, activeSlot);
+#endif
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         class MagicEquipSink : public RE::BSTEventSink<RE::TESEquipEvent> {
         public:
             RE::BSEventNotifyControl ProcessEvent(const RE::TESEquipEvent* a_event,
@@ -34,22 +64,19 @@ namespace IntegratedMagic::MagicAssign {
                 if (!state.IsActive()) return RE::BSEventNotifyControl::kContinue;
 
                 if (auto const* spell = form->As<RE::SpellItem>()) {
-                    const auto& leftMode = state.LeftMode();
-                    const auto& rightMode = state.RightMode();
-
-                    (void)leftMode;
-                    (void)rightMode;
                     const int activeSlot = state.ActiveSlot();
                     if (activeSlot >= 0) {
                         const auto lID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Left);
                         const auto rID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Right);
-                        if (formID == lID || formID == rID) return RE::BSEventNotifyControl::kContinue;
+                        const auto sID = Slots::GetSlotShout(activeSlot);
+                        if (formID == lID || formID == rID || formID == sID) return RE::BSEventNotifyControl::kContinue;
                     }
-
+#ifdef DEBUG
                     spdlog::info(
                         "[Assign] EquipSink: foreign spell {:#010x} equipped during active slot {} -> "
                         "ForceExitNoRestore",
                         formID, state.ActiveSlot());
+#endif
                     if (auto* task = SKSE::GetTaskInterface()) {
                         task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
                     }
@@ -57,10 +84,23 @@ namespace IntegratedMagic::MagicAssign {
                 }
 
                 if (form->As<RE::TESObjectWEAP>() || form->As<RE::TESObjectARMO>() || form->As<RE::TESObjectMISC>()) {
+                    if (form->As<RE::TESObjectWEAP>()) {
+                        const int activeSlot = state.ActiveSlot();
+                        if (IsAssociatedBoundWeaponOfSlot(formID, activeSlot)) {
+#ifdef DEBUG
+                            spdlog::info(
+                                "[Assign] EquipSink: weaponID={:#010x} is bound weapon of active slot {} -> ignoring",
+                                formID, activeSlot);
+#endif
+                            return RE::BSEventNotifyControl::kContinue;
+                        }
+                    }
+#ifdef DEBUG
                     spdlog::info(
                         "[Assign] EquipSink: foreign item {:#010x} (weapon/armor/misc) equipped during active slot {} "
                         "-> ForceExitNoRestore",
                         formID, state.ActiveSlot());
+#endif
                     if (auto* task = SKSE::GetTaskInterface()) {
                         task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
                     }

--- a/src/State/AnimListener.cpp
+++ b/src/State/AnimListener.cpp
@@ -57,7 +57,9 @@ void AnimListener::HandleAnimEvent(const RE::BSAnimationGraphEvent* ev,
 #ifdef DEBUG
         spdlog::info("[AnimListener] >> {} -> ForceExit!", ev->tag.c_str());
 #endif
-        state.ForceExit();
+        if (!state.IsPressMode()) {
+            state.ForceExit();
+        }
     }
     if (tag == "tailMTIdle"sv || tag == "IdleStop"sv) {
         if (state.IsWaitingSheatheRestore()) {

--- a/src/State/MagicStateLifecycle.cpp
+++ b/src/State/MagicStateLifecycle.cpp
@@ -238,8 +238,8 @@ namespace IntegratedMagic {
         auto* pc = GetPlayer();
         if (!pc) return true;
         if (PlayerIsDead(pc)) return true;
-        if (PlayerIsKnockedOrStaggered(pc)) return true;
-        if (PlayerIsBlocking(pc)) return true;
+        if (PlayerIsKnockedOrStaggered(pc) && (!_left.pressActive && !_right.pressActive)) return true;
+        if (PlayerIsBlocking(pc) && (!_left.pressActive && !_right.pressActive)) return true;
         if (!_restore.pendingRestoreAfterSheathe && PlayerIsSheathingOrSheathed(pc)) return true;
 
         if (_session.modeSpellRight) {

--- a/src/State/MagicStatePump.cpp
+++ b/src/State/MagicStatePump.cpp
@@ -186,8 +186,26 @@ namespace IntegratedMagic {
             return;
         }
 
-        if (_left.autoActive && !_left.finished && _left.chargeComplete) FinishHand(Left);
-        if (_right.autoActive && !_right.finished && _right.chargeComplete) FinishHand(Right);
+        if (_left.autoActive && !_left.finished && _left.chargeComplete) {
+            if (_left.pressAutocast) {
+                _left.autoActive = false;
+                _left.chargeComplete = false;
+                _left.waitingChargeComplete = false;
+                _left.pressAutocast = false;
+            } else {
+                FinishHand(Left);
+            }
+        }
+        if (_right.autoActive && !_right.finished && _right.chargeComplete) {
+            if (_right.pressAutocast) {
+                _right.autoActive = false;
+                _right.chargeComplete = false;
+                _right.waitingChargeComplete = false;
+                _right.pressAutocast = false;
+            } else {
+                FinishHand(Right);
+            }
+        }
         if (_left.holdFiredAndWaitingCastStop && !_left.finished) FinishHand(Left);
         if (_right.holdFiredAndWaitingCastStop && !_right.finished) FinishHand(Right);
         TryFinalizeExit();
@@ -491,6 +509,13 @@ namespace IntegratedMagic {
         if (!_session.active) return;
         auto& hm = ModeFor(hand);
         if (hm.autoActive && !hm.finished && hm.chargeComplete) {
+            if (hm.pressAutocast) {
+                hm.autoActive = false;
+                hm.chargeComplete = false;
+                hm.waitingChargeComplete = false;
+                hm.pressAutocast = false;
+                return;
+            }
             if (_session.isDualCasting) {
                 FinishHand(Slots::Hand::Left);
                 FinishHand(Slots::Hand::Right);

--- a/src/State/MagicStateSlot.cpp
+++ b/src/State/MagicStateSlot.cpp
@@ -111,8 +111,26 @@ namespace IntegratedMagic {
                 break;
             case Press:
                 hm.pressActive = true;
+                if (hm.wantAutoAttack) {
+                    hm.autoActive = true;
+                    hm.pressAutocast = true;
+                    hm.waitingChargeComplete = true;
+                    hm.waitingAutoAfterEquip = true;
+                    hm.waitingEnableBumperSecs = 0.f;
+                    hm.waitingBeginCast = true;
+                    hm.beginCastWaitSecs = 0.f;
+                    hm.beginCastRetries = 0;
+                    _session.attackEnabled = false;
+                    if (cfg.skipEquipAnimationPatch) {
+                        _cast.castStopsToSkip = _session.wasHandsDown ? 2 : 1;
+                    } else {
+                        _cast.castStopsToSkip = 0;
+                    }
+                }
 #ifdef DEBUG
-                spdlog::info("[State] EnterHand: hand={} mode=Press", handStr);
+                spdlog::info(
+                    "[State] EnterHand: hand={} mode=Press wantAutoAttack={} pressAutocast={} castStopsToSkip={}",
+                    handStr, hm.wantAutoAttack, hm.pressAutocast, _cast.castStopsToSkip);
 #endif
                 break;
         }

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -30,6 +30,7 @@ namespace IntegratedMagic {
         bool waitingAutoAfterEquip{false};
         bool holdFiredAndWaitingCastStop{false};
         bool finished{false};
+        bool pressAutocast{false};
         float waitingEnableBumperSecs{0.0f};
         bool waitingBeginCast{false};
         float beginCastWaitSecs{0.f};
@@ -134,6 +135,7 @@ namespace IntegratedMagic {
         bool IsWaitingSheatheRestore() const noexcept {
             return _restore.pendingRestoreAfterSheathe && !_restore.sheatheAnimComplete;
         }
+        bool IsPressMode() const noexcept { return _left.pressActive || _right.pressActive; }
         void NotifySheatheComplete() noexcept { _restore.sheatheAnimComplete = true; }
         void OnSpellFired(Slots::Hand hand);
         const HandMode& LeftMode() const noexcept { return _left; }

--- a/src/UI/HUD.cpp
+++ b/src/UI/HUD.cpp
@@ -498,7 +498,7 @@ namespace IntegratedMagic::HUD {
                 }
             }
 
-            if (s.mode == ActivationMode::Hold) {
+            if (s.mode == ActivationMode::Hold || s.mode == ActivationMode::Press) {
                 const ImVec2 cc = {origin.x + availW * 0.5f, origin.y + btnR * 2.f + 6.f + btnR};
                 const bool hov = ManualHover({cc.x - btnR, cc.y - btnR}, {btnR * 2.f, btnR * 2.f});
 

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -329,7 +329,7 @@ namespace {
                 dirty = true;
             }
 
-            if (d.mode == IntegratedMagic::ActivationMode::Hold) {
+            if (d.mode == IntegratedMagic::ActivationMode::Hold || d.mode == IntegratedMagic::ActivationMode::Press) {
                 ImGui::SameLine();
                 bool aa = d.autoAttack;
                 if (ImGui::Checkbox(IntegratedMagic::Strings::Get("Item_AutoCast", "Auto-cast##autocast").c_str(),


### PR DESCRIPTION
fixed a bug where power is not cast

## Summary by Sourcery

Add press-mode auto-cast support while tightening state handling and equip detection for active magic slots.

New Features:
- Enable auto-cast behavior for press activation mode, including state tracking for press-based auto attacks.
- Expose auto-cast configuration and HUD affordances for both hold and press activation modes.

Bug Fixes:
- Prevent premature state termination when the player is knocked, staggered, or blocking during press-mode casting.
- Avoid forcing magic state exit when equip events correspond to the active slot's shout or its associated bound weapon, and ensure auto-cast press mode correctly clears hand state instead of failing to fire powers.

Enhancements:
- Refine animation and equip event handling so force-exit logic is skipped or logged conditionally based on press mode and debug builds.