### PR TITLE
feat(HUD): :sparkles: Conditional visibility for HUD

### DIFF
--- a/src/Config/Config.cpp
+++ b/src/Config/Config.cpp
@@ -110,7 +110,13 @@ namespace IntegratedMagic {
             return;
         }
         const int raw = _getInt(ini, "General", "SlotCount", 4);
-        hudVisible = _getBool(ini, "General", "HudVisible", true);
+        using F = HudVisibilityFlag;
+        std::uint8_t flags = 0;
+        if (_getBool(ini, "General", "HudShowAlways", false)) flags |= static_cast<std::uint8_t>(F::Always);
+        if (_getBool(ini, "General", "HudShowOnSlotActive", false)) flags |= static_cast<std::uint8_t>(F::SlotActive);
+        if (_getBool(ini, "General", "HudShowInCombat", false)) flags |= static_cast<std::uint8_t>(F::InCombat);
+        if (_getBool(ini, "General", "HudShowWeaponDrawn", false)) flags |= static_cast<std::uint8_t>(F::WeaponDrawn);
+        hudVisibilityFlags = flags;
         std::uint32_t v = (raw < 1) ? 1u : static_cast<std::uint32_t>(raw);
         if (v > kMaxSlots) {
             v = kMaxSlots;
@@ -188,7 +194,11 @@ namespace IntegratedMagic {
         ini.LoadFile(path.string().c_str());
         const auto n = SlotCount();
         ini.SetLongValue("General", "SlotCount", static_cast<long>(n));
-        ini.SetBoolValue("General", "HudVisible", hudVisible);
+        using F = HudVisibilityFlag;
+        ini.SetBoolValue("General", "HudShowAlways", HudFlagSet(F::Always));
+        ini.SetBoolValue("General", "HudShowOnSlotActive", HudFlagSet(F::SlotActive));
+        ini.SetBoolValue("General", "HudShowInCombat", HudFlagSet(F::InCombat));
+        ini.SetBoolValue("General", "HudShowWeaponDrawn", HudFlagSet(F::WeaponDrawn));
         for (std::uint32_t i = 0; i < n; ++i) {
             const auto sec = std::format("Magic{}", i + 1);
             _saveInput(ini, sec.c_str(), slotInput[i]);

--- a/src/Config/Config.h
+++ b/src/Config/Config.h
@@ -5,8 +5,8 @@
 #include <cstdint>
 #include <filesystem>
 
-#include "SpellType.h"
 #include "Persistence/SpellSettingsDB.h"
+#include "SpellType.h"
 
 namespace IntegratedMagic {
 
@@ -24,6 +24,14 @@ namespace IntegratedMagic {
         bool autoAttack{true};
     };
 
+    enum class HudVisibilityFlag : std::uint8_t {
+        Never = 0,
+        SlotActive = 1 << 0,
+        InCombat = 1 << 1,
+        WeaponDrawn = 1 << 2,
+        Always = 1 << 3,
+    };
+
     struct MagicConfig {
         static constexpr std::uint32_t kMaxSlots = 64;
         std::atomic<std::uint32_t> slotCount{4};
@@ -33,7 +41,7 @@ namespace IntegratedMagic {
         std::array<InputConfig, kMaxSlots> slotInput;
         InputConfig hudPopupInput;
         std::array<SpellTypeDefaults, static_cast<std::size_t>(SpellType::Shout) + 1> spellTypeDefaults{};
-        bool hudVisible{true};
+        std::uint8_t hudVisibilityFlags{static_cast<std::uint8_t>(HudVisibilityFlag::Always)};
         bool skipEquipAnimationPatch = false;
         bool skipEquipAnimationOnReturnPatch = false;
         bool requireExclusiveHotkeyPatch = false;
@@ -45,6 +53,10 @@ namespace IntegratedMagic {
         void Load();
         void Save() const;
         std::uint32_t SlotCount() const noexcept;
+
+        bool HudFlagSet(HudVisibilityFlag f) const noexcept {
+            return (hudVisibilityFlags & static_cast<std::uint8_t>(f)) != 0;
+        }
 
     private:
         static std::filesystem::path IniPath();

--- a/src/UI/HUD.cpp
+++ b/src/UI/HUD.cpp
@@ -1065,6 +1065,24 @@ namespace IntegratedMagic::HUD {
 
             DrawOverlayAndCursor({io->DisplaySize.x, io->DisplaySize.y}, g_mousePos);
         }
+
+        bool EvaluateHudVisibility() {
+            using F = IntegratedMagic::HudVisibilityFlag;
+            const auto& cfg = IntegratedMagic::GetMagicConfig();
+            if (cfg.hudVisibilityFlags == 0) return false;
+            if (cfg.HudFlagSet(F::Always)) return true;
+            auto* player = RE::PlayerCharacter::GetSingleton();
+            if (!player) return false;
+            if (cfg.HudFlagSet(F::SlotActive) && IntegratedMagic::MagicState::Get().IsActive()) return true;
+            if (cfg.HudFlagSet(F::InCombat) && player->IsInCombat()) return true;
+            if (cfg.HudFlagSet(F::WeaponDrawn)) {
+                const auto ws = player->AsActorState()->GetWeaponState();
+                using WS = RE::WEAPON_STATE;
+                if (ws == WS::kDrawn || ws == WS::kWantToDraw || ws == WS::kDrawing) return true;
+            }
+
+            return false;
+        }
     }
 
     bool IsDetailPopupOpen() { return g_popupWindow && g_popupWindow->IsOpen.load(std::memory_order_relaxed); }
@@ -1100,7 +1118,7 @@ namespace IntegratedMagic::HUD {
         if (inMagicMenu && Input::ConsumeHudToggle()) ToggleDetailPopup();
         if (!inMagicMenu && g_popupWindow && g_popupWindow->IsOpen.load()) g_popupWindow->IsOpen = false;
 
-        if (!g_hudVisible.load(std::memory_order_relaxed)) return;
+        if (!EvaluateHudVisibility()) return;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0.f, 0.f});
 

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -264,13 +264,28 @@ namespace {
         }
 
         ImGui::Spacing();
-        ImGui::Separator();
-        ImGui::Spacing();
-        bool hudVisible = IntegratedMagic::HUD::IsHudVisible();
-        if (ImGui::Checkbox(IntegratedMagic::Strings::Get("Item_ShowHud", "Show HUD").c_str(), &hudVisible)) {
-            IntegratedMagic::HUD::SetHudVisible(hudVisible);
-            cfg.hudVisible = hudVisible;
-            dirty = true;
+        ImGui::SeparatorText(IntegratedMagic::Strings::Get("HUD_Visibility_Label", "HUD Visibility").c_str());
+
+        using F = IntegratedMagic::HudVisibilityFlag;
+        auto flagCheck = [&](F flag, const char* strKey, const char* fallback) {
+            bool v = cfg.HudFlagSet(flag);
+            if (ImGui::Checkbox(IntegratedMagic::Strings::Get(strKey, fallback).c_str(), &v)) {
+                if (v)
+                    cfg.hudVisibilityFlags |= static_cast<std::uint8_t>(flag);
+                else
+                    cfg.hudVisibilityFlags &= ~static_cast<std::uint8_t>(flag);
+                dirty = true;
+            }
+        };
+
+        flagCheck(F::Always, "HUD_Show_Always", "Always");
+        flagCheck(F::SlotActive, "HUD_Show_SlotActive", "Slot Active");
+        flagCheck(F::InCombat, "HUD_Show_InCombat", "In Combat");
+        flagCheck(F::WeaponDrawn, "HUD_Show_WeaponDrawn", "Weapon Drawn");
+
+        if (cfg.hudVisibilityFlags == 0) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("(%s)", IntegratedMagic::Strings::Get("HUD_Show_Never_Hint", "HUD hidden").c_str());
         }
 
         ImGui::Spacing();

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -117,7 +117,6 @@ namespace {
                 IntegratedMagic::StyleConfig::Get().Load();
                 IntegratedMagic::MENU::Register();
                 IntegratedMagic::HUD::Register();
-                IntegratedMagic::HUD::SetHudVisible(IntegratedMagic::GetMagicConfig().hudVisible);
                 IntegratedMagic::TextureManager::Init();
                 Input::OnConfigChanged();
                 IntegratedMagic::Hooks::Install_Hooks();


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable HUD visibility conditions and use them to control when the HUD is rendered instead of a single on/off toggle.

New Features:
- Add HUD visibility flags to allow showing the HUD always, only when a slot is active, in combat, or with weapons drawn, including corresponding menu options.

Enhancements:
- Replace the global HUD visible boolean with a bitmask-based visibility configuration evaluated at render time.
- Persist HUD visibility flag settings in the config file with separate keys for each condition and migrate loading/saving logic accordingly.