### PR TITLE
50 slot shape customization

### DIFF
--- a/cmake/headerlist.cmake
+++ b/cmake/headerlist.cmake
@@ -12,6 +12,7 @@ set(headers
     src/UI/SlotLayout.h
     src/UI/FontLoader.h
     src/UI/Hoveredform.h
+    src/UI/PolyFill.h
     src/Config/ConfigPath.h
     src/Config/Config.h
     src/Config/Slots.h

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -147,11 +147,14 @@ namespace IntegratedMagic::Hooks {
                         io.Fonts->AddFontFromFileTTF(fontPath, fc.size, &mergeCfg, FontLoader::GetGlyphRangesKorean());
                     if (fc.rangeGreek)
                         io.Fonts->AddFontFromFileTTF(fontPath, fc.size, &mergeCfg, FontLoader::GetGlyphRangesGreek());
-
+#ifdef DEBUG
                     spdlog::info("[Hooks] D3DInitHook: loaded font '{}' size {}", fontPath, fc.size);
+#endif
                 } else {
                     io.Fonts->AddFontDefault();
+#ifdef DEBUG
                     spdlog::info("[Hooks] D3DInitHook: font not found, using default");
+#endif
                 }
 
                 WndProcHook::func = reinterpret_cast<WNDPROC>(
@@ -176,6 +179,9 @@ namespace IntegratedMagic::Hooks {
             static constexpr auto id = REL::RelocationID(75461, 77246);
             static constexpr auto offset = REL::VariantOffset(0x9, 0x9, 0x9);
 
+            static inline float s_bbWidth = 0.f;
+            static inline float s_bbHeight = 0.f;
+
             static void thunk(std::uint32_t a_p1) {
                 func(a_p1);
 
@@ -185,10 +191,38 @@ namespace IntegratedMagic::Hooks {
 
                 ImGui_ImplDX11_NewFrame();
                 ImGui_ImplWin32_NewFrame();
+
+                if (s_bbWidth <= 0.f) {
+                    ID3D11RenderTargetView* rtv = nullptr;
+                    g_deviceContext->OMGetRenderTargets(1, &rtv, nullptr);
+                    if (rtv) {
+                        ID3D11Resource* res = nullptr;
+                        rtv->GetResource(&res);
+                        if (res) {
+                            ID3D11Texture2D* tex = nullptr;
+                            if (SUCCEEDED(
+                                    res->QueryInterface(__uuidof(ID3D11Texture2D), reinterpret_cast<void**>(&tex)))) {
+                                D3D11_TEXTURE2D_DESC desc{};
+                                tex->GetDesc(&desc);
+                                s_bbWidth = static_cast<float>(desc.Width);
+                                s_bbHeight = static_cast<float>(desc.Height);
+#ifdef DEBUG
+                                spdlog::info("[Hooks] backbuffer: {}x{}  hwnd: {}x{}", desc.Width, desc.Height,
+                                             static_cast<int>(ImGui::GetIO().DisplaySize.x),
+                                             static_cast<int>(ImGui::GetIO().DisplaySize.y));
+#endif
+                                tex->Release();
+                            }
+                            res->Release();
+                        }
+                        rtv->Release();
+                    }
+                }
+
+                if (s_bbWidth > 0.f) ImGui::GetIO().DisplaySize = {s_bbWidth, s_bbHeight};
+
                 ImGui::NewFrame();
-
                 IntegratedMagic::HUD::DrawHudFrame();
-
                 ImGui::EndFrame();
                 ImGui::Render();
                 ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -443,6 +443,116 @@ namespace {
         }
     }
 
+    void DrawShapeEditor(bool& dirty) {
+        namespace S = IntegratedMagic::Strings;
+        auto& shape = IntegratedMagic::StyleConfig::Get().slotShape;
+        auto& verts = shape.vertices;
+
+        constexpr float kCanvasSize = 200.f;
+        constexpr float kRadius = 80.f;
+
+        ImGuiMCP::ImVec2 origin{};
+        ImGuiMCP::GetCursorScreenPos(&origin);
+        const ImGuiMCP::ImVec2 center = {origin.x + kCanvasSize * 0.5f, origin.y + kCanvasSize * 0.5f};
+        const ImGuiMCP::ImVec2 canvasEnd = {origin.x + kCanvasSize, origin.y + kCanvasSize};
+
+        ImGuiMCP::InvisibleButton("##shapeeditorcanvas", {kCanvasSize, kCanvasSize});
+        const bool canvasHovered = ImGuiMCP::IsItemHovered();
+
+        ImGuiMCP::ImDrawList* dl = ImGuiMCP::GetWindowDrawList();
+        namespace DL = ImGuiMCP::ImDrawListManager;
+
+        DL::AddRectFilled(dl, origin, canvasEnd, IM_COL32(25, 25, 25, 220), 4.f, 0);
+        DL::AddRect(dl, origin, canvasEnd, IM_COL32(80, 80, 80, 180), 4.f, 0, 1.f);
+        DL::AddCircle(dl, center, kRadius, IM_COL32(55, 55, 55, 255), 48, 1.f);
+        DL::AddLine(dl, {center.x - kRadius, center.y}, {center.x + kRadius, center.y}, IM_COL32(50, 50, 50, 200), 1.f);
+        DL::AddLine(dl, {center.x, center.y - kRadius}, {center.x, center.y + kRadius}, IM_COL32(50, 50, 50, 200), 1.f);
+
+        if (verts.size() >= 3) {
+            for (const auto& v : verts) DL::PathLineTo(dl, {center.x + v.x * kRadius, center.y + v.y * kRadius});
+            DL::PathFillConvex(dl, IM_COL32(100, 160, 255, 50));
+
+            for (const auto& v : verts) DL::PathLineTo(dl, {center.x + v.x * kRadius, center.y + v.y * kRadius});
+            DL::PathStroke(dl, IM_COL32(100, 160, 255, 200), ImGuiMCP::ImDrawFlags_Closed, 1.5f);
+        }
+
+        const ImGuiMCP::ImVec2 mousePos = ImGuiMCP::GetIO()->MousePos;
+        static int s_dragging = -1;
+
+        for (int i = 0; i < static_cast<int>(verts.size()); ++i) {
+            const ImGuiMCP::ImVec2 vp = {center.x + verts[i].x * kRadius, center.y + verts[i].y * kRadius};
+            const float dx = mousePos.x - vp.x;
+            const float dy = mousePos.y - vp.y;
+            const bool hovered = canvasHovered && (dx * dx + dy * dy) < 64.f;
+
+            if (hovered && ImGuiMCP::IsMouseClicked(0)) s_dragging = i;
+
+            if (s_dragging == i && ImGuiMCP::IsMouseDown(0)) {
+                verts[i].x = std::clamp((mousePos.x - center.x) / kRadius, -1.f, 1.f);
+                verts[i].y = std::clamp((mousePos.y - center.y) / kRadius, -1.f, 1.f);
+                dirty = true;
+            }
+
+            const ImGuiMCP::ImU32 col =
+                (hovered || s_dragging == i) ? IM_COL32(255, 200, 80, 255) : IM_COL32(200, 200, 200, 220);
+            DL::AddCircleFilled(dl, vp, 6.f, col, 12);
+            DL::AddCircle(dl, vp, 6.f, IM_COL32(0, 0, 0, 180), 12, 1.f);
+
+            if (hovered) ImGuiMCP::SetTooltip("%.2f, %.2f", verts[i].x, verts[i].y);
+        }
+
+        if (!ImGuiMCP::IsMouseDown(0)) s_dragging = -1;
+
+        ImGuiMCP::Spacing();
+
+        if (ImGuiMCP::Button(S::Get("Shape_AddVertex", "+ Vertex").c_str())) {
+            if (verts.size() >= 2) {
+                const auto& a = verts[verts.size() - 1];
+                const auto& b = verts[0];
+                verts.push_back({(a.x + b.x) * 0.5f, (a.y + b.y) * 0.5f});
+            } else {
+                verts.push_back({0.f, -1.f});
+            }
+            dirty = true;
+        }
+        ImGuiMCP::SameLine();
+        ImGuiMCP::BeginDisabled(verts.size() <= 3);
+        if (ImGuiMCP::Button(S::Get("Shape_RemoveVertex", "- Vertex").c_str())) {
+            verts.pop_back();
+            dirty = true;
+        }
+        ImGuiMCP::EndDisabled();
+
+        ImGuiMCP::Spacing();
+        ImGuiMCP::SeparatorText(S::Get("Shape_Presets", "Presets").c_str());
+        ImGuiMCP::Spacing();
+
+        if (ImGuiMCP::Button(S::Get("Shape_Circle", "Circle").c_str())) {
+            shape.SetCircle(16);
+            dirty = true;
+        }
+        ImGuiMCP::SameLine();
+        if (ImGuiMCP::Button(S::Get("Shape_Square", "Square").c_str())) {
+            shape.SetSquare();
+            dirty = true;
+        }
+        ImGuiMCP::SameLine();
+        if (ImGuiMCP::Button(S::Get("Shape_Diamond", "Diamond").c_str())) {
+            shape.SetDiamond();
+            dirty = true;
+        }
+        ImGuiMCP::SameLine();
+        if (ImGuiMCP::Button(S::Get("Shape_Star5", "Star (5)").c_str())) {
+            shape.SetStar(5, 0.45f);
+            dirty = true;
+        }
+        ImGuiMCP::SameLine();
+        if (ImGuiMCP::Button(S::Get("Shape_Star6", "Star (6)").c_str())) {
+            shape.SetStar(6, 0.45f);
+            dirty = true;
+        }
+    }
+
     void DrawHudTab(bool& dirty) {
         namespace S = IntegratedMagic::Strings;
         auto& st = IntegratedMagic::StyleConfig::Get();
@@ -663,6 +773,14 @@ namespace {
                 st.overlayAlpha = static_cast<std::uint8_t>(std::clamp(oa, 0, 255));
                 dirty = true;
             }
+        }
+
+        ImGuiMCP::Spacing();
+
+        if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_SlotShape", "Slot Shape").c_str())) {
+            ImGuiMCP::Spacing();
+            DrawShapeEditor(dirty);
+            ImGuiMCP::Spacing();
         }
 
         ImGuiMCP::Spacing();

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -13,6 +13,7 @@
 #include "SKSEMenuFramework.h"
 #include "Strings.h"
 #include "UI/HudManager.h"
+#include "UI/PolyFill.h"
 #include "UI/StyleConfig.h"
 
 namespace {
@@ -469,8 +470,8 @@ namespace {
         DL::AddLine(dl, {center.x, center.y - kRadius}, {center.x, center.y + kRadius}, IM_COL32(50, 50, 50, 200), 1.f);
 
         if (verts.size() >= 3) {
-            for (const auto& v : verts) DL::PathLineTo(dl, {center.x + v.x * kRadius, center.y + v.y * kRadius});
-            DL::PathFillConvex(dl, IM_COL32(100, 160, 255, 50));
+            for (const auto& t : IntegratedMagic::PolyFill::Triangulate(verts, center.x, center.y, kRadius))
+                DL::AddTriangleFilled(dl, {t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, IM_COL32(100, 160, 255, 50));
 
             for (const auto& v : verts) DL::PathLineTo(dl, {center.x + v.x * kRadius, center.y + v.y * kRadius});
             DL::PathStroke(dl, IM_COL32(100, 160, 255, 200), ImGuiMCP::ImDrawFlags_Closed, 1.5f);

--- a/src/UI/PolyFill.h
+++ b/src/UI/PolyFill.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <vector>
+
+#include "UI/StyleConfig.h"
+
+namespace IntegratedMagic::PolyFill {
+
+    struct Triangle {
+        float ax, ay;
+        float bx, by;
+        float cx, cy;
+    };
+
+    inline std::vector<Triangle> Triangulate(const std::vector<SlotShapeVertex>& verts, float centerX, float centerY,
+                                             float r) {
+        const auto n = static_cast<int>(verts.size());
+        if (n < 3) return {};
+
+        float cx = 0.f, cy = 0.f;
+        for (const auto& v : verts) {
+            cx += centerX + v.x * r;
+            cy += centerY + v.y * r;
+        }
+        cx /= n;
+        cy /= n;
+
+        std::vector<Triangle> tris;
+        tris.reserve(static_cast<std::size_t>(n));
+        for (int i = 0; i < n; ++i) {
+            const int j = (i + 1) % n;
+            tris.push_back({cx, cy, centerX + verts[i].x * r, centerY + verts[i].y * r, centerX + verts[j].x * r,
+                            centerY + verts[j].y * r});
+        }
+        return tris;
+    }
+}

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -74,6 +74,48 @@ namespace IntegratedMagic::HUD::PopupDrawer {
             dl->PathFillConvex(col);
         }
 
+        void FillSlotShapeHighlight(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
+            const auto& shape = StyleConfig::Get().slotShape;
+            if (shape.useCustomShape && shape.vertices.size() >= 3) {
+                for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
+                dl->PathFillConvex(col);
+            } else {
+                dl->AddCircleFilled(center, r, col, 48);
+            }
+        }
+
+        void FillSlotHalfHighlight(ImDrawList* dl, ImVec2 center, float r, bool rightHalf, ImU32 col) {
+            const auto& shape = StyleConfig::Get().slotShape;
+            if (shape.useCustomShape && shape.vertices.size() >= 3) {
+                const float sign = rightHalf ? 1.f : -1.f;
+                std::vector<ImVec2> clipped;
+                const auto& verts = shape.vertices;
+                const int n = static_cast<int>(verts.size());
+                for (int i = 0; i < n; ++i) {
+                    const ImVec2 a = {center.x + verts[i].x * r, center.y + verts[i].y * r};
+                    const ImVec2 b = {center.x + verts[(i + 1) % n].x * r, center.y + verts[(i + 1) % n].y * r};
+                    const float da = (a.x - center.x) * sign;
+                    const float db = (b.x - center.x) * sign;
+                    if (da >= 0.f) clipped.push_back(a);
+                    if ((da >= 0.f) != (db >= 0.f)) {
+                        const float t = da / (da - db);
+                        clipped.push_back({a.x + t * (b.x - a.x), a.y + t * (b.y - a.y)});
+                    }
+                }
+
+                clipped.push_back(center);
+                if (clipped.size() >= 3) {
+                    for (const auto& p : clipped) dl->PathLineTo(p);
+                    dl->PathFillConvex(col);
+                }
+            } else {
+                if (rightHalf)
+                    FillSector(dl, center, r, -kPI * 0.5f, kPI * 0.5f, col);
+                else
+                    FillSector(dl, center, r, kPI * 0.5f, kPI * 1.5f, col);
+            }
+        }
+
         float DrawActionBadge(ImDrawList* dl, ImVec2 origin, float iconSize, const TextureManager::Image& icon,
                               const char* fallbackLabel, const char* actionLabel, ImU32 bgColor) {
             constexpr float kGap = 6.f;
@@ -320,7 +362,7 @@ namespace IntegratedMagic::HUD::PopupDrawer {
                     const float dy = g_mousePos.y - center.y;
                     if ((dx * dx + dy * dy) < (st.popupSlotRadius * st.popupSlotRadius)) {
                         if (hovIsFullSlot) {
-                            dl->AddCircleFilled(center, st.popupSlotRadius - 1.f, IM_COL32(255, 200, 80, 40), 48);
+                            FillSlotShapeHighlight(dl, center, st.popupSlotRadius - 1.f, IM_COL32(255, 200, 80, 40));
                             if (clicked) {
                                 hovIsTwoHanded ? MagicAssign::TryAssignHoveredSpellToSlot(i, Slots::Hand::Left)
                                                : MagicAssign::TryAssignHoveredShoutToSlot(i);
@@ -336,9 +378,8 @@ namespace IntegratedMagic::HUD::PopupDrawer {
                         } else {
                             const bool hoverRight = hovIsRightOnly ? true : hovIsLeftOnly ? false : (dx >= 0.f);
                             const ImU32 hlCol = IM_COL32(255, 200, 80, 40);
-                            hoverRight
-                                ? FillSector(dl, center, st.popupSlotRadius - 1.f, -kPI * 0.5f, kPI * 0.5f, hlCol)
-                                : FillSector(dl, center, st.popupSlotRadius - 1.f, kPI * 0.5f, kPI * 1.5f, hlCol);
+                            hoverRight ? FillSlotHalfHighlight(dl, center, st.popupSlotRadius - 1.f, true, hlCol)
+                                       : FillSlotHalfHighlight(dl, center, st.popupSlotRadius - 1.f, false, hlCol);
                             if (clicked) {
                                 hoverRight ? MagicAssign::TryAssignHoveredSpellToSlot(i, Slots::Hand::Right)
                                            : MagicAssign::TryAssignHoveredSpellToSlot(i, Slots::Hand::Left);

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -104,7 +104,6 @@ namespace IntegratedMagic::HUD::PopupDrawer {
                     }
                 }
 
-                clipped.push_back({0.f, 0.f});
                 if (clipped.size() >= 3) {
                     for (const auto& t : PolyFill::Triangulate(clipped, center.x, center.y, r))
                         dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -17,6 +17,7 @@
 #include "State/State.h"
 #include "Strings.h"
 #include "UI/HoveredForm.h"
+#include "UI/PolyFill.h"
 #include "UI/SlotLayout.h"
 #include "UI/StyleConfig.h"
 #include "UI/TextureManager.h"
@@ -76,9 +77,9 @@ namespace IntegratedMagic::HUD::PopupDrawer {
 
         void FillSlotShapeHighlight(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
             const auto& shape = StyleConfig::Get().slotShape;
-            if (shape.useCustomShape && shape.vertices.size() >= 3) {
-                for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
-                dl->PathFillConvex(col);
+            if (shape.vertices.size() >= 3) {
+                for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
+                    dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
             } else {
                 dl->AddCircleFilled(center, r, col, 48);
             }
@@ -86,16 +87,16 @@ namespace IntegratedMagic::HUD::PopupDrawer {
 
         void FillSlotHalfHighlight(ImDrawList* dl, ImVec2 center, float r, bool rightHalf, ImU32 col) {
             const auto& shape = StyleConfig::Get().slotShape;
-            if (shape.useCustomShape && shape.vertices.size() >= 3) {
+            if (shape.vertices.size() >= 3) {
                 const float sign = rightHalf ? 1.f : -1.f;
-                std::vector<ImVec2> clipped;
+                std::vector<SlotShapeVertex> clipped;
                 const auto& verts = shape.vertices;
                 const int n = static_cast<int>(verts.size());
                 for (int i = 0; i < n; ++i) {
-                    const ImVec2 a = {center.x + verts[i].x * r, center.y + verts[i].y * r};
-                    const ImVec2 b = {center.x + verts[(i + 1) % n].x * r, center.y + verts[(i + 1) % n].y * r};
-                    const float da = (a.x - center.x) * sign;
-                    const float db = (b.x - center.x) * sign;
+                    const SlotShapeVertex& a = verts[i];
+                    const SlotShapeVertex& b = verts[(i + 1) % n];
+                    const float da = a.x * sign;
+                    const float db = b.x * sign;
                     if (da >= 0.f) clipped.push_back(a);
                     if ((da >= 0.f) != (db >= 0.f)) {
                         const float t = da / (da - db);
@@ -103,10 +104,10 @@ namespace IntegratedMagic::HUD::PopupDrawer {
                     }
                 }
 
-                clipped.push_back(center);
+                clipped.push_back({0.f, 0.f});
                 if (clipped.size() >= 3) {
-                    for (const auto& p : clipped) dl->PathLineTo(p);
-                    dl->PathFillConvex(col);
+                    for (const auto& t : PolyFill::Triangulate(clipped, center.x, center.y, r))
+                        dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
                 }
             } else {
                 if (rightHalf)
@@ -429,5 +430,4 @@ namespace IntegratedMagic::HUD::PopupDrawer {
 
         DrawOverlayAndCursor({io.DisplaySize.x, io.DisplaySize.y}, g_mousePos);
     }
-
 }

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -1,6 +1,7 @@
 #include "SlotDrawer.h"
 
 #include <imgui.h>
+#include "UI/PolyFill.h"
 
 #include <chrono>
 #include <cmath>
@@ -138,8 +139,13 @@ namespace IntegratedMagic::HUD::SlotDrawer {
     }
 
     void FillSlotShape(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
-        PathSlotShape(dl, center, r);
-        dl->PathFillConvex(col);
+        const auto& shape = StyleConfig::Get().slotShape;
+        if (shape.vertices.size() >= 3) {
+            for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
+                dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
+        } else {
+            dl->AddCircleFilled(center, r, col, 48);
+        }
     }
 
     void StrokeSlotShape(ImDrawList* dl, ImVec2 center, float r, ImU32 col, float thickness) {
@@ -556,5 +562,4 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
         ImGui::End();
     }
-
 }

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -128,6 +128,42 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         }
     }
 
+    void PathSlotShape(ImDrawList* dl, ImVec2 center, float r) {
+        const auto& shape = StyleConfig::Get().slotShape;
+        if (shape.vertices.size() >= 3) {
+            for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
+        } else {
+            dl->PathArcTo(center, r, 0.f, 2.f * kPI, 48);
+        }
+    }
+
+    void FillSlotShape(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
+        PathSlotShape(dl, center, r);
+        dl->PathFillConvex(col);
+    }
+
+    void StrokeSlotShape(ImDrawList* dl, ImVec2 center, float r, ImU32 col, float thickness) {
+        PathSlotShape(dl, center, r);
+        dl->PathStroke(col, ImDrawFlags_Closed, thickness);
+    }
+
+    void DrawGlowShape(ImDrawList* dl, ImVec2 c, float r, ImU32 glowCol) {
+        const auto& shape = StyleConfig::Get().slotShape;
+        const ImU32 base = glowCol & 0x00FFFFFFu;
+        const auto baseA = static_cast<int>((glowCol >> 24) & 0xFF);
+        if (shape.useCustomShape && shape.vertices.size() >= 3) {
+            for (int i = 5; i >= 1; --i) {
+                const ImU32 layer = base | (static_cast<ImU32>(baseA / (i + 1)) << 24);
+                StrokeSlotShape(dl, c, r + static_cast<float>(i) * 2.5f, layer, 1.2f);
+            }
+        } else {
+            for (int i = 5; i >= 1; --i) {
+                const ImU32 layer = base | (static_cast<ImU32>(baseA / (i + 1)) << 24);
+                dl->AddCircle(c, r + static_cast<float>(i) * 2.5f, layer, 48, 1.2f);
+            }
+        }
+    }
+
     void DrawGlow(ImDrawList* dl, ImVec2 c, float r, ImU32 glowCol) {
         const ImU32 base = glowCol & 0x00FFFFFFu;
         const auto baseA = static_cast<int>((glowCol >> 24) & 0xFF);
@@ -151,8 +187,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         const auto lPal = SpellPalette(lSpell);
 
         if (isActive) {
-            DrawGlow(dl, center, r, rPal.glow);
-            DrawGlow(dl, center, r, lPal.glow);
+            DrawGlowShape(dl, center, r, rPal.glow);
+            DrawGlowShape(dl, center, r, lPal.glow);
         }
 
         const auto& st = Style();
@@ -170,12 +206,13 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                 return TextureManager::GetUiTexture(UiTextureType::slot_bg);
             }();
             if (bgImg.valid())
+
                 dl->AddImage(reinterpret_cast<ImTextureID>(bgImg.texture), {center.x - r, center.y - r},
                              {center.x + r, center.y + r}, {0.f, 0.f}, {1.f, 1.f}, IM_COL32(255, 255, 255, 255));
             else
-                dl->AddCircleFilled(center, r, isActive ? st.slotBgActive : st.slotBgInactive, 48);
+                FillSlotShape(dl, center, r, isActive ? st.slotBgActive : st.slotBgInactive);
         } else {
-            dl->AddCircleFilled(center, r, isActive ? st.slotBgActive : st.slotBgInactive, 48);
+            FillSlotShape(dl, center, r, isActive ? st.slotBgActive : st.slotBgInactive);
         }
 
         const float iconSize = r * st.iconSizeFactor;
@@ -198,10 +235,10 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             const double pulse = 0.65 + 0.35 * std::sin(t * 4.5);
             const ImU32 ring =
                 IM_COL32(255, static_cast<int>(210 * pulse), static_cast<int>(50 * pulse), st.slotRingActiveAlpha);
-            dl->AddCircle(center, r, ring, 48, st.slotRingWidth);
-            dl->AddCircle(center, r + st.slotRingWidth + 0.5f, (ring & 0x00FFFFFFu) | (70u << 24), 48, 1.0f);
+            StrokeSlotShape(dl, center, r, ring, st.slotRingWidth);
+            StrokeSlotShape(dl, center, r + st.slotRingWidth + 0.5f, (ring & 0x00FFFFFFu) | (70u << 24), 1.0f);
         } else {
-            dl->AddCircle(center, r, st.slotRingInactive, 48, st.slotRingWidth * 0.5f);
+            StrokeSlotShape(dl, center, r, st.slotRingInactive, st.slotRingWidth * 0.5f);
         }
 
         if (!rSpell && !lSpell && !shoutFormID) {
@@ -464,7 +501,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             return LayoutVec2{h.x + kGlowPad, h.y + kGlowPad};
         }();
 
-        const ImVec2 hudOrigin = ComputeHudCenter(io, {fixedHalf.x, fixedHalf.y});
+        const ImVec2 hudOrigin = ComputeHudCenter(io, {animHalf.x, animHalf.y});
 
         LayoutVec2 relPos[SlotLayout::kMaxSlots]{};
         SlotLayout::Compute(st.hudLayout, n, st.slotRadius, st.ringRadius, st.slotSpacing, st.gridColumns, relPos);

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -1,10 +1,15 @@
 #include "StyleConfig.h"
 
+#include <cmath>
+#include <numbers>
+
 #include "PCH.h"
 #include "SimpleIni.h"
 
 namespace IntegratedMagic {
     namespace {
+        constexpr float kPI = std::numbers::pi_v<float>;
+
         float GetFloat(const CSimpleIniA& ini, const char* section, const char* key, float def) {
             const char* v = ini.GetValue(section, key, nullptr);
             if (!v) return def;
@@ -99,8 +104,28 @@ namespace IntegratedMagic {
         }
     }
 
+    void SlotShapeConfig::SetCircle(int segments) {
+        vertices.clear();
+        for (int i = 0; i < segments; ++i) {
+            const float a = (2.f * kPI * i) / segments - kPI * 0.5f;
+            vertices.push_back({std::cos(a), std::sin(a)});
+        }
+    }
+    void SlotShapeConfig::SetSquare() { vertices = {{-1, -1}, {1, -1}, {1, 1}, {-1, 1}}; }
+    void SlotShapeConfig::SetDiamond() { vertices = {{0, -1}, {1, 0}, {0, 1}, {-1, 0}}; }
+    void SlotShapeConfig::SetStar(int points, float inner) {
+        vertices.clear();
+        for (int i = 0; i < points * 2; ++i) {
+            const float a = (kPI * i / points) - kPI * 0.5f;
+            const float r = (i % 2 == 0) ? 1.f : inner;
+            vertices.push_back({r * std::cos(a), r * std::sin(a)});
+        }
+    }
+
     void StyleConfig::Load() {
         constexpr const char* kPath = R"(.\Data\SKSE\Plugins\IntegratedMagics\styles.ini)";
+        auto& shape = slotShape;
+        auto& verts = slotShape.vertices;
 
         CSimpleIniA ini;
         ini.SetUnicode();
@@ -119,6 +144,17 @@ namespace IntegratedMagic {
         font.rangeChineseSimplified = ini.GetBoolValue("Font", "RangeChineseSimplified", false);
         font.rangeKorean = ini.GetBoolValue("Font", "RangeKorean", false);
         font.rangeGreek = ini.GetBoolValue("Font", "RangeGreek", false);
+
+        long count = ini.GetLongValue("SlotShape", "Count", 0);
+        verts.clear();
+        for (long i = 0; i < count; ++i) {
+            std::string key = "V" + std::to_string(i);
+            std::string val = ini.GetValue("SlotShape", key.c_str(), "0,0");
+            float x = 0.f, y = 0.f;
+            sscanf_s(val.c_str(), "%f,%f", &x, &y);
+            verts.push_back({x, y});
+        }
+        if (verts.empty()) shape.SetCircle();
 
         slotRadius = GetFloat(ini, "HUD", "SlotRadius", slotRadius);
         ringRadius = GetFloat(ini, "HUD", "RingRadius", ringRadius);
@@ -205,6 +241,7 @@ namespace IntegratedMagic {
 
     void StyleConfig::Save() {
         constexpr const char* kPath = R"(.\Data\SKSE\Plugins\IntegratedMagics\styles.ini)";
+        auto& verts = slotShape.vertices;
 
         CSimpleIniA ini;
         ini.SetUnicode();
@@ -213,7 +250,7 @@ namespace IntegratedMagic {
         auto setFloat = [&](const char* sec, const char* key, float v) {
             std::string s = std::to_string(v);
 
-            if (s.find('.') != std::string::npos) {
+            if (s.contains('.')) {
                 s.erase(s.find_last_not_of('0') + 1);
                 if (s.back() == '.') s += '0';
             }
@@ -237,6 +274,13 @@ namespace IntegratedMagic {
         static const char* kButtonLabelVisibilityNames[] = {"Never", "Always", "OnModifier"};
         static const char* kButtonLabelCornerNames[] = {"Top",  "Right",        "Bottom",
                                                         "Left", "TowardCenter", "AwayFromCenter"};
+
+        for (int i = 0; i < verts.size(); ++i) {
+            std::string key = "V" + std::to_string(i);
+            std::string val = std::to_string(verts[i].x) + "," + std::to_string(verts[i].y);
+            ini.SetValue("SlotShape", key.c_str(), val.c_str());
+        }
+        ini.SetLongValue("SlotShape", "Count", static_cast<long>(verts.size()));
 
         ini.SetValue("Font", "Path", font.path.c_str());
         setFloat("Font", "Size", font.size);

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -61,8 +61,24 @@ namespace IntegratedMagic {
         bool rangeGreek = false;
     };
 
+    struct SlotShapeVertex {
+        float x = 0.f;
+        float y = 0.f;
+    };
+
+    struct SlotShapeConfig {
+        std::vector<SlotShapeVertex> vertices;
+        bool useCustomShape = false;
+
+        void SetCircle(int segments = 16);
+        void SetSquare();
+        void SetDiamond();
+        void SetStar(int points = 5, float innerFactor = 0.45f);
+    };
+
     struct StyleConfig {
         FontConfig font;
+        SlotShapeConfig slotShape;
         float slotRadius = 32.f;
         float ringRadius = 54.f;
         float popupSlotRadius = 48.f;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,5 +12,5 @@
       "features": ["dx11-binding", "win32-binding", "freetype"]
     }
   ],
-  "builtin-baseline": "b94ab47c998b93fe72b0f501eaac70f96328019e"
+  "builtin-baseline": "c27eeddba73f608f10605d80bc0144c1166f8fb7"
 }


### PR DESCRIPTION
## Summary by Sourcery

Add customizable HUD slot shapes with editor UI, persistence, and rendering support, plus minor ImGui/DirectX hook adjustments.

New Features:
- Introduce a slot shape configuration model with support for preset shapes and custom vertex-based polygons.
- Add an in-game shape editor UI for configuring HUD slot shapes, including presets and vertex manipulation.

Enhancements:
- Update HUD, popup, and glow rendering to use the configurable slot shape instead of hard-coded circles, including half-slot highlights and shape-aware glow effects.
- Persist custom slot shapes to the styles configuration file and restore them on load, defaulting to a circular shape when none is defined.
- Adjust ImGui DirectX hook to derive display size from the backbuffer and conditionally log font loading information in debug builds.

Build:
- Register the new PolyFill header in the CMake header list.