### PR TITLE
62 more options for slot color customization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(${PROJECT_NAME}
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 
 find_package(imgui CONFIG REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE imgui::imgui)
+target_link_libraries(${PROJECT_NAME} PRIVATE imgui::imgui xinput.lib)
 
 target_precompile_headers(${PROJECT_NAME} PRIVATE src/PCH.h)
 

--- a/cmake/headerlist.cmake
+++ b/cmake/headerlist.cmake
@@ -13,6 +13,7 @@ set(headers
     src/UI/FontLoader.h
     src/UI/Hoveredform.h
     src/UI/PolyFill.h
+    src/UI/HudTextUtil.h
     src/Config/ConfigPath.h
     src/Config/Config.h
     src/Config/Slots.h

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -5,11 +5,13 @@
 #include <imgui.h>
 #include <imgui_impl_dx11.h>
 #include <imgui_impl_win32.h>
+#include <xinput.h>
 
 #include <utility>
 
 #include "HookUtil.hpp"
 #include "Input/Input.h"
+#include "Input/Inputstate.h"
 #include "PCH.h"
 #include "State/AnimListener.h"
 #include "State/State.h"
@@ -29,8 +31,11 @@ namespace IntegratedMagic::Hooks {
                 if (!a_events) return;
 
                 Input::ProcessAndFilter(const_cast<RE::InputEvent**>(a_events));
+
+                RE::InputEvent* head = IntegratedMagic::detail::FlushSyntheticInput(*a_events);
+
                 if (func == 0) return;
-                RE::InputEvent* const arr[2]{*a_events, nullptr};
+                RE::InputEvent* const arr[2]{head, nullptr};
                 reinterpret_cast<Fn*>(func)(a_dispatcher, arr);
             }
 
@@ -74,16 +79,68 @@ namespace IntegratedMagic::Hooks {
             static LRESULT thunk(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
                 if (g_renderInitialized.load()) {
                     ImGui::SetCurrentContext(g_imguiContext);
-                    if (uMsg == WM_KILLFOCUS) {
-                        auto& io = ImGui::GetIO();
-                        io.ClearInputCharacters();
-                        io.ClearInputKeys();
+
+                    if (Input::IsCaptureModeActive()) {
+                        if (uMsg == WM_KEYDOWN || uMsg == WM_SYSKEYDOWN) {
+                            const UINT sc = (lParam >> 16) & 0x7F;
+                            if (sc > 0 && sc < static_cast<UINT>(kMouseButtonBase))
+                                Input::InjectCapturedScancode(static_cast<int>(sc));
+                        } else if (uMsg == WM_LBUTTONDOWN) {
+                            Input::InjectCapturedScancode(kMouseButtonBase + 0);
+                        } else if (uMsg == WM_RBUTTONDOWN) {
+                            Input::InjectCapturedScancode(kMouseButtonBase + 1);
+                        } else if (uMsg == WM_MBUTTONDOWN) {
+                            Input::InjectCapturedScancode(kMouseButtonBase + 2);
+                        }
                     }
-                    ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);
+
+                    if (!Input::IsCaptureModeActive()) {
+                        if (uMsg == WM_KILLFOCUS) {
+                            auto& io = ImGui::GetIO();
+                            io.ClearInputCharacters();
+                            io.ClearInputKeys();
+                        }
+                        const bool popupOpen = IntegratedMagic::HUD::IsDetailPopupOpen();
+                        const bool isMouseMsg =
+                            (uMsg == WM_LBUTTONDOWN || uMsg == WM_LBUTTONUP || uMsg == WM_RBUTTONDOWN ||
+                             uMsg == WM_RBUTTONUP || uMsg == WM_MBUTTONDOWN || uMsg == WM_MBUTTONUP ||
+                             uMsg == WM_MOUSEMOVE || uMsg == WM_MOUSEWHEEL);
+
+                        if (!isMouseMsg || popupOpen) {
+                            ImGui_ImplWin32_WndProcHandler(hWnd, uMsg, wParam, lParam);
+                        }
+                    }
                 }
                 return func(hWnd, uMsg, wParam, lParam);
             }
         };
+
+        static int PollGamepadCapture() {
+            static constexpr std::pair<WORD, int> kMap[] = {
+                {XINPUT_GAMEPAD_DPAD_UP, 0},
+                {XINPUT_GAMEPAD_DPAD_DOWN, 1},
+                {XINPUT_GAMEPAD_DPAD_LEFT, 2},
+                {XINPUT_GAMEPAD_DPAD_RIGHT, 3},
+                {XINPUT_GAMEPAD_START, 4},
+                {XINPUT_GAMEPAD_BACK, 5},
+                {XINPUT_GAMEPAD_LEFT_THUMB, 6},
+                {XINPUT_GAMEPAD_RIGHT_THUMB, 7},
+                {XINPUT_GAMEPAD_LEFT_SHOULDER, 8},
+                {XINPUT_GAMEPAD_RIGHT_SHOULDER, 9},
+                {XINPUT_GAMEPAD_A, 10},
+                {XINPUT_GAMEPAD_B, 11},
+                {XINPUT_GAMEPAD_X, 12},
+                {XINPUT_GAMEPAD_Y, 13},
+            };
+            XINPUT_STATE state{};
+            if (XInputGetState(0, &state) != ERROR_SUCCESS) return -1;
+            for (const auto& [mask, idx] : kMap)
+                if (state.Gamepad.wButtons & mask) return idx;
+
+            if (state.Gamepad.bLeftTrigger > 64) return 14;
+            if (state.Gamepad.bRightTrigger > 64) return 15;
+            return -1;
+        }
 
         struct D3DInitHook {
             using FuncType = void (*)();
@@ -220,6 +277,19 @@ namespace IntegratedMagic::Hooks {
                 }
 
                 if (s_bbWidth > 0.f) ImGui::GetIO().DisplaySize = {s_bbWidth, s_bbHeight};
+
+                if (Input::IsCaptureModeActive()) {
+                    static bool s_prevMouse[5]{};
+                    constexpr int kMouseVKs[5] = {VK_LBUTTON, VK_RBUTTON, VK_MBUTTON, VK_XBUTTON1, VK_XBUTTON2};
+                    for (int i = 0; i < 5; ++i) {
+                        const bool down = (GetAsyncKeyState(kMouseVKs[i]) & 0x8000) != 0;
+                        if (down && !s_prevMouse[i]) Input::InjectCapturedScancode(kMouseButtonBase + i);
+                        s_prevMouse[i] = down;
+                    }
+
+                    const int gpIdx = PollGamepadCapture();
+                    if (gpIdx >= 0) Input::InjectCapturedGamepad(gpIdx);
+                }
 
                 ImGui::NewFrame();
                 IntegratedMagic::HUD::DrawHudFrame();

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -221,7 +221,9 @@ namespace IntegratedMagic::Hooks {
                 }
 
                 g_renderInitialized.store(true);
+#ifdef DEBUG
                 spdlog::info("[Hooks] D3DInitHook: ImGui HUD context initialized");
+#endif
             }
 
             static void Install() {

--- a/src/Input/Eventfilter.h
+++ b/src/Input/Eventfilter.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "InputState.h"
-#include "RE/I/InputEvent.h"
+#include "Input/InputState.h"
+#include "PCH.h"
 
 namespace Input::detail {
 

--- a/src/Input/Exclusivepending.cpp
+++ b/src/Input/Exclusivepending.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "ExclusivePending.h"
 
 #include "Config/Config.h"
@@ -129,9 +131,9 @@ namespace Input::detail {
                             return true;
                         }
 
-                        const bool anyHeld = (src == PendingSrc::Gp) ? AnyComboKeyDown(hk.gp, g_gpDown)
-                                                                     : AnyComboKeyDown(hk.kb, g_kbDown);
-                        if (anyHeld) {
+                        if (const bool anyHeld = (src == PendingSrc::Gp) ? AnyComboKeyDown(hk.gp, g_gpDown)
+                                                                         : AnyComboKeyDown(hk.kb, g_kbDown);
+                            anyHeld) {
                             g_exclusivePendingTimer[s] -= dt;
                             if (g_exclusivePendingTimer[s] <= 0.0f) {
 #ifdef DEBUG
@@ -195,8 +197,8 @@ namespace Input::detail {
                 const bool kbExclOk = !requireExcl || !kbIsMulti ||
                                       ComboExclusiveNow(hk.kb, g_kbDown, IsAllowedExtra_Keyboard_MoveOrCamera);
                 if (kbExclOk) {
-                    const bool kbSimPatch = cfg.pressBothAtSamePatch && kbIsMulti;
-                    if (kbSimPatch && !g_simWindowActive[s]) {
+                    if (const bool kbSimPatch = cfg.pressBothAtSamePatch && kbIsMulti;
+                        kbSimPatch && !g_simWindowActive[s]) {
 #ifdef DEBUG
                         spdlog::info(
                             "[Input] ComputeAcceptedExclusive: slot={} KB edge REJECTED by sim-window "
@@ -223,8 +225,8 @@ namespace Input::detail {
                 const bool gpExclOk = !requireExcl || !gpIsMulti ||
                                       ComboExclusiveNow(hk.gp, g_gpDown, IsAllowedExtra_Gamepad_MoveOrCamera);
                 if (gpExclOk) {
-                    const bool gpSimPatch = cfg.pressBothAtSamePatch && gpIsMulti;
-                    if (gpSimPatch && !g_simWindowActive[s]) {
+                    if (const bool gpSimPatch = cfg.pressBothAtSamePatch && gpIsMulti;
+                        gpSimPatch && !g_simWindowActive[s]) {
 #ifdef DEBUG
                         spdlog::info(
                             "[Input] ComputeAcceptedExclusive: slot={} GP edge REJECTED by sim-window "
@@ -254,7 +256,7 @@ namespace Input::detail {
         if (g_exclusivePendingSrc[s] != PendingSrc::None || !g_retainedEvents[s].empty()) {
 #ifdef DEBUG
             spdlog::info("[Input] DiscardExclusivePending: slot={} (had pending src={} retained={})", s,
-                         static_cast<int>(g_exclusivePendingSrc[s]), g_retainedEvents[s].size());
+                         static_cast<int>(std::to_underlying(g_exclusivePendingSrc[s])), g_retainedEvents[s].size());
 #endif
         }
         g_retainedEvents[s].clear();

--- a/src/Input/Input.cpp
+++ b/src/Input/Input.cpp
@@ -2,14 +2,14 @@
 
 #include <chrono>
 
-#include "EventFilter.h"
-#include "ExclusivePending.h"
-#include "HotkeyCache.h"
-#include "HudToggle.h"
-#include "InputInternal.h"
-#include "InputState.h"
+#include "Input/EventFilter.h"
+#include "Input/ExclusivePending.h"
+#include "Input/HotkeyCache.h"
+#include "Input/HudToggle.h"
+#include "Input/InputInternal.h"
+#include "Input/InputState.h"
+#include "Input/ReplaySystem.h"
 #include "PCH.h"
-#include "ReplaySystem.h"
 #include "SKSEMenuFramework.h"
 #include "State/State.h"
 #include "UI/HudManager.h"
@@ -112,7 +112,6 @@ void Input::ProcessAndFilter(RE::InputEvent** a_evns) {
     }
 
     Input::detail::DrainOneDeferredReplayEvent();
-    *a_evns = IntegratedMagic::detail::FlushSyntheticInput(*a_evns);
 
     ClearStuckKeysOnFocusRegain();
 
@@ -238,3 +237,24 @@ bool Input::IsModifierHeld() {
 }
 
 void Input::SetCaptureModeActive(bool active) { g_captureModeActive.store(active, std::memory_order_relaxed); }
+
+bool Input::IsCaptureModeActive() { return g_captureModeActive.load(std::memory_order_relaxed); }
+
+void Input::InjectCapturedScancode(int scancode) {
+    auto& cap = GetCaptureState();
+    if (!cap.captureRequested.load(std::memory_order_relaxed)) return;
+    spdlog::info("[Input] InjectCapturedScancode: scancode={}", scancode);
+    cap.capturedEncoded.store(scancode, std::memory_order_relaxed);
+    cap.captureRequested.store(false, std::memory_order_relaxed);
+    g_captureModeActive.store(false, std::memory_order_relaxed);
+}
+
+void Input::InjectCapturedGamepad(int buttonIndex) {
+    auto& cap = GetCaptureState();
+    if (!cap.captureRequested.load(std::memory_order_relaxed)) return;
+    const int encoded = -(buttonIndex + 2);
+    spdlog::info("[Input] InjectCapturedGamepad: index={} encoded={}", buttonIndex, encoded);
+    cap.capturedEncoded.store(encoded, std::memory_order_relaxed);
+    cap.captureRequested.store(false, std::memory_order_relaxed);
+    g_captureModeActive.store(false, std::memory_order_relaxed);
+}

--- a/src/Input/Input.cpp
+++ b/src/Input/Input.cpp
@@ -11,10 +11,41 @@
 #include "Input/ReplaySystem.h"
 #include "PCH.h"
 #include "SKSEMenuFramework.h"
+#include "State/Assign.h"
+#include "State/SpellClassify.h"
 #include "State/State.h"
+#include "UI/HoveredForm.h"
 #include "UI/HudManager.h"
 
 namespace {
+
+    void TryAssignHoveredToSlotByHotkey() {
+        auto* ui = RE::UI::GetSingleton();
+        if (!ui) return;
+        static const RE::BSFixedString magicMenu{"MagicMenu"};
+        if (!ui->IsMenuOpen(magicMenu)) return;
+
+        const auto type = IntegratedMagic::HoveredForm::GetHoveredMagicType();
+        if (type == IntegratedMagic::HoveredForm::MagicType::None) return;
+
+        const int n = ActiveSlots();
+        for (int slot = 0; slot < n; ++slot) {
+            const auto& hk = g_cache[static_cast<std::size_t>(slot)];
+            const bool comboDown =
+                Input::detail::ComboDown(hk.kb, g_kbDown) || Input::detail::ComboDown(hk.gp, g_gpDown);
+            if (!comboDown) continue;
+
+            using MT = IntegratedMagic::HoveredForm::MagicType;
+            if (type == MT::Shout || type == MT::Power) {
+                IntegratedMagic::MagicAssign::TryAssignHoveredShoutToSlot(slot);
+            } else if (type == MT::RightOnlySpell) {
+                IntegratedMagic::MagicAssign::TryAssignHoveredSpellToSlot(slot, IntegratedMagic::Slots::Hand::Right);
+            } else {
+                IntegratedMagic::MagicAssign::TryAssignHoveredSpellToSlot(slot, IntegratedMagic::Slots::Hand::Left);
+            }
+            break;
+        }
+    }
 
     float CalculateDeltaTime() {
         using clock = std::chrono::steady_clock;
@@ -155,6 +186,9 @@ void Input::ProcessAndFilter(RE::InputEvent** a_evns) {
 
     Input::detail::ProcessButtonEvents(a_evns, cap, wantCapture);
     Input::detail::UpdateHudToggleState();
+
+    if (blocked) TryAssignHoveredToSlotByHotkey();
+
     Input::detail::UpdateSlotsIfAllowed(blocked, dt);
     Input::detail::FilterMouseForPopup(a_evns);
 

--- a/src/Input/Input.cpp
+++ b/src/Input/Input.cpp
@@ -63,8 +63,21 @@ namespace {
         GetWindowThreadProcessId(fg, &fgPid);
         const bool focused = (fgPid == GetCurrentProcessId());
 
+        const bool justLostFocus = (s_prevFocused && !focused);
         const bool justRegainedFocus = (!s_prevFocused && focused);
         s_prevFocused = focused;
+
+        if (justLostFocus) {
+            for (const auto& [idx, vk] : kMouseVKMap) {
+                const auto i = static_cast<std::size_t>(idx);
+                if (g_kbDown[i].load(std::memory_order_relaxed)) {
+#ifdef DEBUG
+                    spdlog::info("[Input] ClearStuckKeysOnFocusRegain: focus lost, clearing mouse button idx={}", idx);
+#endif
+                    g_kbDown[i].store(false, std::memory_order_relaxed);
+                }
+            }
+        }
 
         if (!justRegainedFocus) return;
 
@@ -243,7 +256,9 @@ bool Input::IsCaptureModeActive() { return g_captureModeActive.load(std::memory_
 void Input::InjectCapturedScancode(int scancode) {
     auto& cap = GetCaptureState();
     if (!cap.captureRequested.load(std::memory_order_relaxed)) return;
+#ifdef DEBUG
     spdlog::info("[Input] InjectCapturedScancode: scancode={}", scancode);
+#endif
     cap.capturedEncoded.store(scancode, std::memory_order_relaxed);
     cap.captureRequested.store(false, std::memory_order_relaxed);
     g_captureModeActive.store(false, std::memory_order_relaxed);
@@ -253,7 +268,9 @@ void Input::InjectCapturedGamepad(int buttonIndex) {
     auto& cap = GetCaptureState();
     if (!cap.captureRequested.load(std::memory_order_relaxed)) return;
     const int encoded = -(buttonIndex + 2);
+#ifdef DEBUG
     spdlog::info("[Input] InjectCapturedGamepad: index={} encoded={}", buttonIndex, encoded);
+#endif
     cap.capturedEncoded.store(encoded, std::memory_order_relaxed);
     cap.captureRequested.store(false, std::memory_order_relaxed);
     g_captureModeActive.store(false, std::memory_order_relaxed);

--- a/src/Input/Input.h
+++ b/src/Input/Input.h
@@ -2,10 +2,9 @@
 
 #include <optional>
 
-#include "RE/I/InputEvent.h"
+#include "PCH.h"
 
 namespace Input {
-
     void ProcessAndFilter(RE::InputEvent** a_evns);
     void OnConfigChanged();
     [[nodiscard]] std::optional<int> GetDownSlotForSelection();
@@ -16,4 +15,7 @@ namespace Input {
     [[nodiscard]] bool ConsumeHudToggle();
     [[nodiscard]] bool IsModifierHeld();
     void SetCaptureModeActive(bool active);
+    [[nodiscard]] bool IsCaptureModeActive();
+    void InjectCapturedScancode(int scancode);
+    void InjectCapturedGamepad(int buttonIndex);
 }

--- a/src/State/Equipsink.cpp
+++ b/src/State/Equipsink.cpp
@@ -64,17 +64,67 @@ namespace IntegratedMagic::EquipSink {
 
                 if (auto const* spell = form->As<RE::SpellItem>()) {
                     const int activeSlot = state.ActiveSlot();
-                    if (activeSlot >= 0) {
-                        const auto lID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Left);
-                        const auto rID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Right);
-                        const auto sID = Slots::GetSlotShout(activeSlot);
-                        if (formID == lID || formID == rID || formID == sID) return RE::BSEventNotifyControl::kContinue;
-                    }
+                    if (activeSlot < 0) return RE::BSEventNotifyControl::kContinue;
                     if (state.IsInSlotSetup()) return RE::BSEventNotifyControl::kContinue;
+
+                    const auto lID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Left);
+                    const auto rID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Right);
+                    const auto sID = Slots::GetSlotShout(activeSlot);
+
+                    if (formID == lID || formID == rID || formID == sID) return RE::BSEventNotifyControl::kContinue;
+
+                    const bool isPower = (spell->GetSpellType() == RE::MagicSystem::SpellType::kPower ||
+                                          spell->GetSpellType() == RE::MagicSystem::SpellType::kLesserPower);
+                    if (isPower) {
+                        if (!sID) return RE::BSEventNotifyControl::kContinue;
+#ifdef DEBUG
+                        spdlog::info(
+                            "[EquipSink] foreign power {:#010x} equipped during active slot {} -> ForceExitNoRestore",
+                            formID, activeSlot);
+#endif
+                        if (auto* task = SKSE::GetTaskInterface()) {
+                            task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
+                        }
+                        return RE::BSEventNotifyControl::kContinue;
+                    }
+
+                    const auto* rightEntry = player->GetEquippedEntryData(false);
+                    const auto* leftEntry = player->GetEquippedEntryData(true);
+
+                    const RE::FormID rightNow =
+                        (rightEntry && rightEntry->GetObject()) ? rightEntry->GetObject()->GetFormID() : 0;
+                    const RE::FormID leftNow =
+                        (leftEntry && leftEntry->GetObject()) ? leftEntry->GetObject()->GetFormID() : 0;
+
+                    const bool isInRightHand = (rightNow == formID);
+                    const bool isInLeftHand = (leftNow == formID);
+
+                    const bool conflictsRight = isInRightHand && (rID != 0);
+                    const bool conflictsLeft = isInLeftHand && (lID != 0);
+
+                    if (!conflictsRight && !conflictsLeft) return RE::BSEventNotifyControl::kContinue;
 #ifdef DEBUG
                     spdlog::info(
-                        "[EquipSink] foreign spell {:#010x} equipped during active slot {} -> ForceExitNoRestore",
-                        formID, state.ActiveSlot());
+                        "[EquipSink] foreign spell {:#010x} equipped in {} hand during active slot {} -> "
+                        "ForceExitNoRestore",
+                        formID, isInRightHand ? "right" : "left", activeSlot);
+#endif
+                    if (auto* task = SKSE::GetTaskInterface()) {
+                        task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
+                    }
+                    return RE::BSEventNotifyControl::kContinue;
+                }
+
+                if (form->As<RE::TESShout>()) {
+                    const int activeSlot = state.ActiveSlot();
+                    if (activeSlot < 0) return RE::BSEventNotifyControl::kContinue;
+                    const auto sID = Slots::GetSlotShout(activeSlot);
+                    if (!sID) return RE::BSEventNotifyControl::kContinue;
+                    if (formID == sID) return RE::BSEventNotifyControl::kContinue;
+#ifdef DEBUG
+                    spdlog::info(
+                        "[EquipSink] foreign shout/power {:#010x} equipped during active slot {} -> ForceExitNoRestore",
+                        formID, activeSlot);
 #endif
                     if (auto* task = SKSE::GetTaskInterface()) {
                         task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
@@ -83,27 +133,54 @@ namespace IntegratedMagic::EquipSink {
                 }
 
                 if (form->As<RE::TESObjectWEAP>() || form->As<RE::TESObjectARMO>() || form->As<RE::TESObjectMISC>()) {
-                    if (form->As<RE::TESObjectWEAP>()) {
-                        const int activeSlot = state.ActiveSlot();
-                        if (IsAssociatedBoundWeaponOfSlot(formID, activeSlot)) {
+                    const int activeSlot = state.ActiveSlot();
+                    if (activeSlot < 0) return RE::BSEventNotifyControl::kContinue;
+                    if (state.IsInSlotSetup() || state.IsShoutActive()) return RE::BSEventNotifyControl::kContinue;
+
+                    if (form->As<RE::TESObjectWEAP>() && IsAssociatedBoundWeaponOfSlot(formID, activeSlot)) {
 #ifdef DEBUG
-                            spdlog::info("[EquipSink] weaponID={:#010x} is bound weapon of active slot {} -> ignoring",
-                                         formID, activeSlot);
+                        spdlog::info("[EquipSink] weaponID={:#010x} is bound weapon of active slot {} -> ignoring",
+                                     formID, activeSlot);
 #endif
-                            return RE::BSEventNotifyControl::kContinue;
-                        }
+                        return RE::BSEventNotifyControl::kContinue;
                     }
 
-                    if (state.IsInSlotSetup() || state.IsShoutActive()) return RE::BSEventNotifyControl::kContinue;
+                    const auto lID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Left);
+                    const auto rID = Slots::GetSlotSpell(activeSlot, Slots::Hand::Right);
+
+                    if (form->As<RE::TESObjectARMO>()) {
+                        const auto* armature = form->As<RE::TESObjectARMO>();
+                        const bool isShield = armature->HasPartOf(RE::BGSBipedObjectForm::BipedObjectSlot::kShield);
+                        if (!isShield) return RE::BSEventNotifyControl::kContinue;
+                        if (!lID) return RE::BSEventNotifyControl::kContinue;
+#ifdef DEBUG
+                        spdlog::info(
+                            "[EquipSink] shield {:#010x} in left hand conflicts with slot {} -> ForceExitNoRestore",
+                            formID, activeSlot);
+#endif
+                        if (auto* task = SKSE::GetTaskInterface())
+                            task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
+                        return RE::BSEventNotifyControl::kContinue;
+                    }
+
+                    const auto* rightEntry = player->GetEquippedEntryData(false);
+                    const auto* leftEntry = player->GetEquippedEntryData(true);
+                    const RE::FormID rightNow =
+                        (rightEntry && rightEntry->GetObject()) ? rightEntry->GetObject()->GetFormID() : 0;
+                    const RE::FormID leftNow =
+                        (leftEntry && leftEntry->GetObject()) ? leftEntry->GetObject()->GetFormID() : 0;
+
+                    const bool conflictsRight = (rightNow == formID) && (rID != 0);
+                    const bool conflictsLeft = (leftNow == formID) && (lID != 0);
+
+                    if (!conflictsRight && !conflictsLeft) return RE::BSEventNotifyControl::kContinue;
 #ifdef DEBUG
                     spdlog::info(
-                        "[EquipSink] foreign item {:#010x} (weapon/armor/misc) equipped during active slot {} "
-                        "-> ForceExitNoRestore",
-                        formID, state.ActiveSlot());
+                        "[EquipSink] weapon/misc {:#010x} in {} hand conflicts with slot {} -> ForceExitNoRestore",
+                        formID, conflictsRight ? "right" : "left", activeSlot);
 #endif
-                    if (auto* task = SKSE::GetTaskInterface()) {
+                    if (auto* task = SKSE::GetTaskInterface())
                         task->AddTask([]() { MagicState::Get().ForceExitNoRestore(); });
-                    }
                 }
 
                 return RE::BSEventNotifyControl::kContinue;
@@ -127,5 +204,4 @@ namespace IntegratedMagic::EquipSink {
             spdlog::info("[EquipSink] TESEquipEvent sink registered.");
         }
     }
-
 }

--- a/src/State/MagicStatePump.cpp
+++ b/src/State/MagicStatePump.cpp
@@ -466,6 +466,7 @@ namespace IntegratedMagic {
         PumpAutoStartFallback(Right, dt);
         PumpAutomaticHand(Left);
         PumpAutomaticHand(Right);
+        PumpSpellFireFinalize(dt);
 
         if (!_session.active) return;
 
@@ -507,7 +508,9 @@ namespace IntegratedMagic {
 
     void MagicState::OnSpellFired(Slots::Hand hand) {
         if (!_session.active) return;
+
         auto& hm = ModeFor(hand);
+
         if (hm.autoActive && !hm.finished && hm.chargeComplete) {
             if (hm.pressAutocast) {
                 hm.autoActive = false;
@@ -516,14 +519,53 @@ namespace IntegratedMagic {
                 hm.pressAutocast = false;
                 return;
             }
+
             if (_session.isDualCasting) {
                 FinishHand(Slots::Hand::Left);
                 FinishHand(Slots::Hand::Right);
                 _session.isDualCasting = false;
+
+                ScheduleSpellFireFinalize(Slots::Hand::Left);
+                ScheduleSpellFireFinalize(Slots::Hand::Right);
             } else {
                 FinishHand(hand);
+                ScheduleSpellFireFinalize(hand);
             }
-            TryFinalizeExit();
         }
+    }
+
+    void MagicState::ScheduleSpellFireFinalize(Slots::Hand hand) {
+        auto& hm = ModeFor(hand);
+        hm.waitingSpellFireFinalize = true;
+        hm.spellFireFinalizeSecs = 0.f;
+    }
+
+    void MagicState::PumpSpellFireFinalize(float dt) {
+        if (!_session.active) {
+            _left.waitingSpellFireFinalize = false;
+            _left.spellFireFinalizeSecs = 0.f;
+            _right.waitingSpellFireFinalize = false;
+            _right.spellFireFinalizeSecs = 0.f;
+            return;
+        }
+
+        constexpr float kSpellFireFinalizeDelay = 0.7f;
+
+        auto pumpOne = [&](Slots::Hand hand) {
+            auto& hm = ModeFor(hand);
+            if (!hm.waitingSpellFireFinalize) return;
+
+            hm.spellFireFinalizeSecs += dt > 0.f ? dt : 0.f;
+            if (hm.spellFireFinalizeSecs < kSpellFireFinalizeDelay) return;
+
+            hm.waitingSpellFireFinalize = false;
+            hm.spellFireFinalizeSecs = 0.f;
+
+            TryFinalizeExit();
+        };
+
+        using enum Slots::Hand;
+        pumpOne(Left);
+        pumpOne(Right);
     }
 }

--- a/src/State/State.h
+++ b/src/State/State.h
@@ -37,6 +37,8 @@ namespace IntegratedMagic {
         bool waitingBeginCast{false};
         float beginCastWaitSecs{0.f};
         int beginCastRetries{0};
+        bool waitingSpellFireFinalize{false};
+        float spellFireFinalizeSecs{0.f};
     };
 
     struct SessionState {
@@ -251,6 +253,8 @@ namespace IntegratedMagic {
         void PumpDelayedStarts(float dt);
         void PumpAutomaticHand(Slots::Hand hand);
         void PumpAutoStartFallback(Slots::Hand hand, float dt);
+        void ScheduleSpellFireFinalize(Slots::Hand hand);
+        void PumpSpellFireFinalize(float dt);
 
         void StartShoutPress();
         void StopShoutPress();

--- a/src/UI/HudManager.cpp
+++ b/src/UI/HudManager.cpp
@@ -84,7 +84,9 @@ namespace IntegratedMagic::HUD {
 
         const bool inMagicMenu = IsInMagicMenu();
         if (inMagicMenu && Input::ConsumeHudToggle()) ToggleDetailPopup();
-        if (!inMagicMenu && g_popupOpen.load()) g_popupOpen.store(false);
+        if (!inMagicMenu && g_popupOpen.load()) {
+            g_popupOpen.store(false);
+        }
 
         if (EvaluateHudVisibility()) {
             ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.f);
@@ -107,13 +109,35 @@ namespace IntegratedMagic::HUD {
     void FeedMouseClick() { g_mouseClicked.store(true, std::memory_order_relaxed); }
     void FeedMouseRightClick() { g_mouseRightClicked.store(true, std::memory_order_relaxed); }
 
+    namespace {
+        void SetMagicMenuVisible(bool visible) {
+            auto* ui = RE::UI::GetSingleton();
+            if (!ui) return;
+            static const RE::BSFixedString magicMenu{"MagicMenu"};
+            auto menu = ui->GetMenu<RE::MagicMenu>();
+            if (!menu || !menu->uiMovie) return;
+            RE::GFxValue val(visible);
+            menu->uiMovie->SetVariable("_root.Menu_mc._visible", val);
+        }
+    }
+
     void ToggleDetailPopup() {
         const bool willOpen = !g_popupOpen.load();
         g_popupOpen.store(willOpen);
-        if (willOpen) g_popupJustOpened.store(true, std::memory_order_relaxed);
+        if (willOpen) {
+            g_popupJustOpened.store(true, std::memory_order_relaxed);
+            SetMagicMenuVisible(false);
+        } else {
+            SetMagicMenuVisible(true);
+        }
     }
 
-    void CloseDetailPopup() { g_popupOpen.store(false); }
+    void CloseDetailPopup() {
+        if (g_popupOpen.load()) {
+            g_popupOpen.store(false);
+            SetMagicMenuVisible(true);
+        }
+    }
     bool IsHudVisible() { return g_hudVisible.load(std::memory_order_relaxed); }
     void SetHudVisible(bool v) { g_hudVisible.store(v, std::memory_order_relaxed); }
 

--- a/src/UI/HudManager.cpp
+++ b/src/UI/HudManager.cpp
@@ -8,8 +8,6 @@
 #include "Input/Input.h"
 #include "PCH.h"
 #include "PopupDrawer.h"
-#include "RE/P/PlayerCharacter.h"
-#include "RE/U/UI.h"
 #include "SlotDrawer.h"
 #include "State/State.h"
 
@@ -61,18 +59,18 @@ namespace IntegratedMagic::HUD {
     }
 
     bool EvaluateHudVisibility() {
-        using F = IntegratedMagic::HudVisibilityFlag;
+        using enum IntegratedMagic::HudVisibilityFlag;
         const auto& cfg = IntegratedMagic::GetMagicConfig();
         if (cfg.hudVisibilityFlags == 0) return false;
-        if (cfg.HudFlagSet(F::Always)) return true;
+        if (cfg.HudFlagSet(Always)) return true;
         auto* player = RE::PlayerCharacter::GetSingleton();
         if (!player) return false;
-        if (cfg.HudFlagSet(F::SlotActive) && IntegratedMagic::MagicState::Get().IsActive()) return true;
-        if (cfg.HudFlagSet(F::InCombat) && player->IsInCombat()) return true;
-        if (cfg.HudFlagSet(F::WeaponDrawn)) {
-            using WS = RE::WEAPON_STATE;
+        if (cfg.HudFlagSet(SlotActive) && IntegratedMagic::MagicState::Get().IsActive()) return true;
+        if (cfg.HudFlagSet(InCombat) && player->IsInCombat()) return true;
+        if (cfg.HudFlagSet(WeaponDrawn)) {
+            using enum RE::WEAPON_STATE;
             const auto ws = player->AsActorState()->GetWeaponState();
-            if (ws == WS::kDrawn || ws == WS::kWantToDraw || ws == WS::kDrawing) return true;
+            if (ws == kDrawn || ws == kWantToDraw || ws == kDrawing) return true;
         }
         return false;
     }

--- a/src/UI/HudTextUtil.h
+++ b/src/UI/HudTextUtil.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <imgui.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace IntegratedMagic::HUD {
+
+    inline void DrawWrappedLabelAbove(const char* text, float columnLeftX, float maxWidth, float slotTopY,
+                                      float margin = 4.f, bool centered = false) {
+        if (!text || text[0] == '\0') return;
+        const float lineHeight = ImGui::GetTextLineHeight();
+        std::vector<std::string> lines;
+        std::string current;
+        std::istringstream stream(text);
+        std::string word;
+        while (stream >> word) {
+            const std::string candidate = current.empty() ? word : current + " " + word;
+            if (ImGui::CalcTextSize(candidate.c_str()).x <= maxWidth)
+                current = candidate;
+            else {
+                if (!current.empty()) lines.push_back(current);
+                current = word;
+            }
+        }
+        if (!current.empty()) lines.push_back(current);
+        float y = slotTopY - margin - static_cast<float>(lines.size()) * lineHeight;
+        for (const auto& line : lines) {
+            float x = columnLeftX;
+            if (centered) {
+                const float lineW = ImGui::CalcTextSize(line.c_str()).x;
+                x = columnLeftX + (maxWidth - lineW) * 0.5f;
+            }
+            ImGui::SetCursorScreenPos({x, y});
+            ImGui::TextDisabled("%s", line.c_str());
+            y += lineHeight;
+        }
+    }
+}

--- a/src/UI/HudTextUtil.h
+++ b/src/UI/HudTextUtil.h
@@ -6,11 +6,14 @@
 #include <string>
 #include <vector>
 
+#include "UI/StyleConfig.h"
+
 namespace IntegratedMagic::HUD {
 
     inline void DrawWrappedLabelAbove(const char* text, float columnLeftX, float maxWidth, float slotTopY,
                                       float margin = 4.f, bool centered = false) {
         if (!text || text[0] == '\0') return;
+        const auto& st = StyleConfig::Get();
         const float lineHeight = ImGui::GetTextLineHeight();
         std::vector<std::string> lines;
         std::string current;
@@ -27,11 +30,19 @@ namespace IntegratedMagic::HUD {
         }
         if (!current.empty()) lines.push_back(current);
         float y = slotTopY - margin - static_cast<float>(lines.size()) * lineHeight;
+
+        ImDrawList* dl = ImGui::GetWindowDrawList();
+
         for (const auto& line : lines) {
             float x = columnLeftX;
             if (centered) {
                 const float lineW = ImGui::CalcTextSize(line.c_str()).x;
                 x = columnLeftX + (maxWidth - lineW) * 0.5f;
+            }
+
+            if (st.textShadowEnabled && dl) {
+                const ImVec2 shadowPos = {x + st.textShadowOffsetX, y + st.textShadowOffsetY};
+                dl->AddText(shadowPos, st.textShadowColor, line.c_str());
             }
             ImGui::SetCursorScreenPos({x, y});
             ImGui::TextDisabled("%s", line.c_str());

--- a/src/UI/HudTextUtil.h
+++ b/src/UI/HudTextUtil.h
@@ -44,8 +44,12 @@ namespace IntegratedMagic::HUD {
                 const ImVec2 shadowPos = {x + st.textShadowOffsetX, y + st.textShadowOffsetY};
                 dl->AddText(shadowPos, st.textShadowColor, line.c_str());
             }
-            ImGui::SetCursorScreenPos({x, y});
-            ImGui::TextDisabled("%s", line.c_str());
+            if (dl) {
+                dl->AddText({x, y}, st.textColor, line.c_str());
+            } else {
+                ImGui::SetCursorScreenPos({x, y});
+                ImGui::TextDisabled("%s", line.c_str());
+            }
             y += lineHeight;
         }
     }

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -558,221 +558,244 @@ namespace {
         namespace S = IntegratedMagic::Strings;
         auto& st = IntegratedMagic::StyleConfig::Get();
 
-        ImGuiMCP::SeparatorText(S::Get("HUD_Section_Layout", "Layout").c_str());
+        if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_InGame", "In-game HUD").c_str())) {
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Layout", "Layout").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                using LT = IntegratedMagic::HudLayoutType;
+                const std::string layoutNames =
+                    S::Get("HUD_Layout_Circular", "Circular") + '\0' + S::Get("HUD_Layout_Horizontal", "Horizontal") +
+                    '\0' + S::Get("HUD_Layout_Vertical", "Vertical") + '\0' + S::Get("HUD_Layout_Grid", "Grid") + '\0';
+                int layoutIdx = static_cast<int>(st.hudLayout);
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::Combo(S::Get("HUD_Layout_Label", "Layout##hudlayout").c_str(), &layoutIdx,
+                                    layoutNames.c_str())) {
+                    st.hudLayout = static_cast<LT>(layoutIdx);
+                    dirty = true;
+                }
+
+                {
+                    ImGuiMCP::SameLine();
+                    ImGuiMCP::SetNextItemWidth(150.f);
+                    float spacing = st.slotSpacing;
+                    if (ImGuiMCP::InputFloat(S::Get("HUD_Spacing_Label", "Spacing##slotspacing").c_str(), &spacing, 1.f,
+                                             5.f, "%.1f")) {
+                        st.slotSpacing = spacing;
+                        dirty = true;
+                    }
+                }
+                if (st.hudLayout == LT::Grid) {
+                    ImGuiMCP::SetNextItemWidth(150.f);
+                    int cols = st.gridColumns;
+                    if (ImGuiMCP::InputInt(S::Get("HUD_Columns_Label", "Columns##gridcols").c_str(), &cols, 1, 1)) {
+                        st.gridColumns = std::max(1, cols);
+                        dirty = true;
+                    }
+                }
+                if (st.hudLayout == LT::Circular) {
+                    ImGuiMCP::SetNextItemWidth(150.f);
+                    float rr = st.ringRadius;
+                    if (ImGuiMCP::InputFloat(S::Get("HUD_RingRadius_Label", "Ring R##ringradius").c_str(), &rr, 1.f,
+                                             5.f, "%.1f")) {
+                        st.ringRadius = rr;
+                        dirty = true;
+                    }
+                }
+            }
+
+            ImGuiMCP::Spacing();
+
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Position", "Position").c_str());
+            ImGuiMCP::Spacing();
+
+            DrawAnchorWidget(dirty);
+
+            ImGuiMCP::SameLine(0.f, 16.f);
+            ImGuiMCP::BeginGroup();
+            ImGuiMCP::SetNextItemWidth(150.f);
+            float ox = st.hudOffsetX;
+            if (ImGuiMCP::InputFloat(S::Get("HUD_OffsetX_Label", "X##hudox").c_str(), &ox, 1.f, 5.f, "%.0f")) {
+                st.hudOffsetX = ox;
+                dirty = true;
+            }
+            ImGuiMCP::SetNextItemWidth(150.f);
+            float oy = st.hudOffsetY;
+            if (ImGuiMCP::InputFloat(S::Get("HUD_OffsetY_Label", "Y##hudoy").c_str(), &oy, 1.f, 5.f, "%.0f")) {
+                st.hudOffsetY = oy;
+                dirty = true;
+            }
+            ImGuiMCP::EndGroup();
+
+            ImGuiMCP::Spacing();
+
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Slots", "Slots").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float sr = st.slotRadius;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_SlotRadius_Label", "Radius##slotradius").c_str(), &sr, 1.f, 5.f,
+                                         "%.1f")) {
+                    st.slotRadius = sr;
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float rw = st.slotRingWidth;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_RingWidth_Label", "Ring Width##ringwidth").c_str(), &rw, 0.5f, 1.f,
+                                         "%.1f")) {
+                    st.slotRingWidth = std::max(0.f, rw);
+                    dirty = true;
+                }
+                ImGuiMCP::Spacing();
+
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float as = st.slotActiveScale;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_ActiveScale_Label", "Active##activescale").c_str(), &as, 0.05f,
+                                         0.1f, "%.2f")) {
+                    st.slotActiveScale = as;
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float ms = st.slotModifierScale;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_ModifierScale_Label", "Modifier##modscale").c_str(), &ms, 0.05f,
+                                         0.1f, "%.2f")) {
+                    st.slotModifierScale = ms;
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float ns = st.slotNeighborScale;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_NeighborScale_Label", "Neighbor##neighborscale").c_str(), &ns,
+                                         0.05f, 0.1f, "%.2f")) {
+                    st.slotNeighborScale = ns;
+                    dirty = true;
+                }
+                ImGuiMCP::Spacing();
+
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float et = st.slotExpandTime;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_ExpandTime_Label", "Expand##expandtime").c_str(), &et, 0.01f,
+                                         0.05f, "%.2f")) {
+                    st.slotExpandTime = std::max(0.f, et);
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float rt = st.slotRetractTime;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_RetractTime_Label", "Retract##retracttime").c_str(), &rt, 0.01f,
+                                         0.05f, "%.2f")) {
+                    st.slotRetractTime = std::max(0.f, rt);
+                    dirty = true;
+                }
+            }
+
+            ImGuiMCP::Spacing();
+
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Icons", "Icons").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float isf = st.iconSizeFactor;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_IconSize_Label", "Size##iconsizefactor").c_str(), &isf, 0.05f,
+                                         0.1f, "%.2f")) {
+                    st.iconSizeFactor = std::clamp(isf, 0.1f, 2.f);
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float iof = st.iconOffsetFactor;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_IconOffset_Label", "Offset##iconoffsetfactor").c_str(), &iof,
+                                         0.05f, 0.1f, "%.2f")) {
+                    st.iconOffsetFactor = std::clamp(iof, 0.f, 1.f);
+                    dirty = true;
+                }
+            }
+
+            ImGuiMCP::Spacing();
+        }
+
         ImGuiMCP::Spacing();
 
-        {
-            using LT = IntegratedMagic::HudLayoutType;
-            const std::string layoutNames =
-                S::Get("HUD_Layout_Circular", "Circular") + '\0' + S::Get("HUD_Layout_Horizontal", "Horizontal") +
-                '\0' + S::Get("HUD_Layout_Vertical", "Vertical") + '\0' + S::Get("HUD_Layout_Grid", "Grid") + '\0';
-            int layoutIdx = static_cast<int>(st.hudLayout);
-            ImGuiMCP::SetNextItemWidth(150.f);
-            if (ImGuiMCP::Combo(S::Get("HUD_Layout_Label", "Layout##hudlayout").c_str(), &layoutIdx,
-                                layoutNames.c_str())) {
-                st.hudLayout = static_cast<LT>(layoutIdx);
-                dirty = true;
+        if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_Popup", "Popup").c_str())) {
+            ImGuiMCP::Spacing();
+
+            {
+                const std::string popupLayoutNames =
+                    S::Get("HUD_Layout_Circular", "Circular") + '\0' + S::Get("HUD_Layout_Horizontal", "Horizontal") +
+                    '\0' + S::Get("HUD_Layout_Vertical", "Vertical") + '\0' + S::Get("HUD_Layout_Grid", "Grid") + '\0';
+                int popupLayoutIdx = static_cast<int>(st.popupLayout);
+                ImGuiMCP::SetNextItemWidth(180.f);
+                if (ImGuiMCP::Combo(S::Get("HUD_PopupLayout_Label", "Layout##popuplayout").c_str(), &popupLayoutIdx,
+                                    popupLayoutNames.c_str())) {
+                    st.popupLayout = static_cast<IntegratedMagic::HudLayoutType>(popupLayoutIdx);
+                    dirty = true;
+                }
+                ImGuiMCP::Spacing();
             }
 
             {
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float psr = st.popupSlotRadius;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupSlotR_Label", "Slot R##popupslotradius").c_str(), &psr, 1.f,
+                                         5.f, "%.0f")) {
+                    st.popupSlotRadius = std::max(1.f, psr);
+                    dirty = true;
+                }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float spacing = st.slotSpacing;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_Spacing_Label", "Spacing##slotspacing").c_str(), &spacing, 1.f,
-                                         5.f, "%.1f")) {
-                    st.slotSpacing = spacing;
+                float prr = st.popupRingRadius;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupRingR_Label", "Ring R##popupringradius").c_str(), &prr, 1.f,
+                                         5.f, "%.0f")) {
+                    st.popupRingRadius = std::max(1.f, prr);
                     dirty = true;
                 }
-            }
-            if (st.hudLayout == LT::Grid) {
+                ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                int cols = st.gridColumns;
-                if (ImGuiMCP::InputInt(S::Get("HUD_Columns_Label", "Columns##gridcols").c_str(), &cols, 1, 1)) {
-                    st.gridColumns = std::max(1, cols);
+                float psg = st.popupSlotGap;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupGap_Label", "Gap##popupslotgap").c_str(), &psg, 1.f, 5.f,
+                                         "%.0f")) {
+                    st.popupSlotGap = psg;
                     dirty = true;
                 }
-            }
-            if (st.hudLayout == LT::Circular) {
+                ImGuiMCP::Spacing();
+
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float rr = st.ringRadius;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_RingRadius_Label", "Ring R##ringradius").c_str(), &rr, 1.f, 5.f,
-                                         "%.1f")) {
-                    st.ringRadius = rr;
+                float mww = st.modeWidgetW;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_ModeWidgetW_Label", "Widget W##modewidgetw").c_str(), &mww, 1.f,
+                                         5.f, "%.0f")) {
+                    st.modeWidgetW = std::max(1.f, mww);
                     dirty = true;
                 }
-            }
-        }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                int oa = static_cast<int>(st.overlayAlpha);
+                if (ImGuiMCP::InputInt(S::Get("HUD_OverlayAlpha_Label", "Overlay Alpha##overlayalpha").c_str(), &oa, 5,
+                                       20)) {
+                    st.overlayAlpha = static_cast<std::uint8_t>(std::clamp(oa, 0, 255));
+                    dirty = true;
+                }
 
-        ImGuiMCP::Spacing();
+                ImGuiMCP::Spacing();
 
-        ImGuiMCP::SeparatorText(S::Get("HUD_Section_Position", "Position").c_str());
-        ImGuiMCP::Spacing();
-
-        DrawAnchorWidget(dirty);
-
-        ImGuiMCP::SameLine(0.f, 16.f);
-        ImGuiMCP::BeginGroup();
-        ImGuiMCP::SetNextItemWidth(150.f);
-        float ox = st.hudOffsetX;
-        if (ImGuiMCP::InputFloat(S::Get("HUD_OffsetX_Label", "X##hudox").c_str(), &ox, 1.f, 5.f, "%.0f")) {
-            st.hudOffsetX = ox;
-            dirty = true;
-        }
-        ImGuiMCP::SetNextItemWidth(150.f);
-        float oy = st.hudOffsetY;
-        if (ImGuiMCP::InputFloat(S::Get("HUD_OffsetY_Label", "Y##hudoy").c_str(), &oy, 1.f, 5.f, "%.0f")) {
-            st.hudOffsetY = oy;
-            dirty = true;
-        }
-        ImGuiMCP::EndGroup();
-
-        ImGuiMCP::Spacing();
-
-        ImGuiMCP::SeparatorText(S::Get("HUD_Section_Slots", "Slots").c_str());
-        ImGuiMCP::Spacing();
-
-        {
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float sr = st.slotRadius;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_SlotRadius_Label", "Radius##slotradius").c_str(), &sr, 1.f, 5.f,
-                                     "%.1f")) {
-                st.slotRadius = sr;
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float rw = st.slotRingWidth;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_RingWidth_Label", "Ring Width##ringwidth").c_str(), &rw, 0.5f, 1.f,
-                                     "%.1f")) {
-                st.slotRingWidth = std::max(0.f, rw);
-                dirty = true;
-            }
-            ImGuiMCP::Spacing();
-
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float as = st.slotActiveScale;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_ActiveScale_Label", "Active##activescale").c_str(), &as, 0.05f, 0.1f,
-                                     "%.2f")) {
-                st.slotActiveScale = as;
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float ms = st.slotModifierScale;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_ModifierScale_Label", "Modifier##modscale").c_str(), &ms, 0.05f, 0.1f,
-                                     "%.2f")) {
-                st.slotModifierScale = ms;
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float ns = st.slotNeighborScale;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_NeighborScale_Label", "Neighbor##neighborscale").c_str(), &ns, 0.05f,
-                                     0.1f, "%.2f")) {
-                st.slotNeighborScale = ns;
-                dirty = true;
-            }
-            ImGuiMCP::Spacing();
-
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float et = st.slotExpandTime;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_ExpandTime_Label", "Expand##expandtime").c_str(), &et, 0.01f, 0.05f,
-                                     "%.2f")) {
-                st.slotExpandTime = std::max(0.f, et);
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float rt = st.slotRetractTime;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_RetractTime_Label", "Retract##retracttime").c_str(), &rt, 0.01f, 0.05f,
-                                     "%.2f")) {
-                st.slotRetractTime = std::max(0.f, rt);
-                dirty = true;
-            }
-        }
-
-        ImGuiMCP::Spacing();
-
-        ImGuiMCP::SeparatorText(S::Get("HUD_Section_Icons", "Icons").c_str());
-        ImGuiMCP::Spacing();
-
-        {
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float isf = st.iconSizeFactor;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_IconSize_Label", "Size##iconsizefactor").c_str(), &isf, 0.05f, 0.1f,
-                                     "%.2f")) {
-                st.iconSizeFactor = std::clamp(isf, 0.1f, 2.f);
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float iof = st.iconOffsetFactor;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_IconOffset_Label", "Offset##iconoffsetfactor").c_str(), &iof, 0.05f,
-                                     0.1f, "%.2f")) {
-                st.iconOffsetFactor = std::clamp(iof, 0.f, 1.f);
-                dirty = true;
-            }
-        }
-
-        ImGuiMCP::Spacing();
-
-        ImGuiMCP::SeparatorText(S::Get("HUD_Section_Popup", "Popup").c_str());
-        ImGuiMCP::Spacing();
-
-        {
-            const std::string popupLayoutNames =
-                S::Get("HUD_Layout_Circular", "Circular") + '\0' + S::Get("HUD_Layout_Horizontal", "Horizontal") +
-                '\0' + S::Get("HUD_Layout_Vertical", "Vertical") + '\0' + S::Get("HUD_Layout_Grid", "Grid") + '\0';
-            int popupLayoutIdx = static_cast<int>(st.popupLayout);
-            ImGuiMCP::SetNextItemWidth(180.f);
-            if (ImGuiMCP::Combo(S::Get("HUD_PopupLayout_Label", "Layout##popuplayout").c_str(), &popupLayoutIdx,
-                                popupLayoutNames.c_str())) {
-                st.popupLayout = static_cast<IntegratedMagic::HudLayoutType>(popupLayoutIdx);
-                dirty = true;
-            }
-            ImGuiMCP::Spacing();
-        }
-
-        {
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float psr = st.popupSlotRadius;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_PopupSlotR_Label", "Slot R##popupslotradius").c_str(), &psr, 1.f, 5.f,
-                                     "%.0f")) {
-                st.popupSlotRadius = std::max(1.f, psr);
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float prr = st.popupRingRadius;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_PopupRingR_Label", "Ring R##popupringradius").c_str(), &prr, 1.f, 5.f,
-                                     "%.0f")) {
-                st.popupRingRadius = std::max(1.f, prr);
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float psg = st.popupSlotGap;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_PopupGap_Label", "Gap##popupslotgap").c_str(), &psg, 1.f, 5.f,
-                                     "%.0f")) {
-                st.popupSlotGap = psg;
-                dirty = true;
-            }
-            ImGuiMCP::Spacing();
-
-            ImGuiMCP::SetNextItemWidth(150.f);
-            float mww = st.modeWidgetW;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_ModeWidgetW_Label", "Widget W##modewidgetw").c_str(), &mww, 1.f, 5.f,
-                                     "%.0f")) {
-                st.modeWidgetW = std::max(1.f, mww);
-                dirty = true;
-            }
-            ImGuiMCP::SameLine();
-            ImGuiMCP::SetNextItemWidth(150.f);
-            int oa = static_cast<int>(st.overlayAlpha);
-            if (ImGuiMCP::InputInt(S::Get("HUD_OverlayAlpha_Label", "Overlay Alpha##overlayalpha").c_str(), &oa, 5,
-                                   20)) {
-                st.overlayAlpha = static_cast<std::uint8_t>(std::clamp(oa, 0, 255));
-                dirty = true;
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float pox = st.popupOffsetX;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupOffsetX_Label", "Offset X##popupox").c_str(), &pox, 1.f, 5.f,
+                                         "%.0f")) {
+                    st.popupOffsetX = pox;
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float poy = st.popupOffsetY;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupOffsetY_Label", "Offset Y##popupoy").c_str(), &poy, 1.f, 5.f,
+                                         "%.0f")) {
+                    st.popupOffsetY = poy;
+                    dirty = true;
+                }
             }
         }
 

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -764,9 +764,27 @@ namespace {
                     dirty = true;
                 }
             }
+            {
+                float ts = st.iconTintStrength;
+                ImGuiMCP::SetNextItemWidth(200.f);
+                if (ImGuiMCP::SliderFloat(S::Get("HUD_Icon_TintStrength", "Tint Strength##icontintstrength").c_str(),
+                                          &ts, 0.f, 1.f, "%.2f")) {
+                    st.iconTintStrength = ts;
+                    dirty = true;
+                }
+                if (ImGuiMCP::IsItemHovered())
+                    ImGuiMCP::SetTooltip(
+                        S::Get("HUD_Icon_TintStrength_Tip",
+                               "0 = sem tint  |  1 = força máxima (controlada pelo alpha da Tint Color)")
+                            .c_str());
+            }
 
             ImGuiMCP::Spacing();
             ImGuiMCP::SeparatorText(S::Get("HUD_Section_Text", "Text").c_str());
+            ImGuiMCP::Spacing();
+
+            colorEdit(S::Get("HUD_Text_Color", "Text Color##textcolor").c_str(), st.textColor);
+
             ImGuiMCP::Spacing();
 
             {

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -694,6 +694,17 @@ namespace {
 
             ImGuiMCP::Spacing();
 
+            {
+                bool showNames = st.showSpellNamesInHud;
+                if (ImGuiMCP::Checkbox(S::Get("HUD_ShowSpellNames", "Show spell names##showspellnames").c_str(),
+                                       &showNames)) {
+                    st.showSpellNamesInHud = showNames;
+                    dirty = true;
+                }
+            }
+
+            ImGuiMCP::Spacing();
+
             ImGuiMCP::SeparatorText(S::Get("HUD_Section_Icons", "Icons").c_str());
             ImGuiMCP::Spacing();
 

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -558,6 +558,30 @@ namespace {
         namespace S = IntegratedMagic::Strings;
         auto& st = IntegratedMagic::StyleConfig::Get();
 
+        auto colorEdit = [&](const char* label, std::uint32_t& col) {
+            float c[4];
+            c[0] = ((col >> 0) & 0xFF) / 255.f;
+            c[1] = ((col >> 8) & 0xFF) / 255.f;
+            c[2] = ((col >> 16) & 0xFF) / 255.f;
+            c[3] = ((col >> 24) & 0xFF) / 255.f;
+            if (ImGuiMCP::ColorEdit4(
+                    label, c, ImGuiMCP::ImGuiColorEditFlags_AlphaBar | ImGuiMCP::ImGuiColorEditFlags_AlphaPreview)) {
+                col = (static_cast<std::uint32_t>(c[3] * 255.f + .5f) << 24) |
+                      (static_cast<std::uint32_t>(c[2] * 255.f + .5f) << 16) |
+                      (static_cast<std::uint32_t>(c[1] * 255.f + .5f) << 8) |
+                      static_cast<std::uint32_t>(c[0] * 255.f + .5f);
+                dirty = true;
+            }
+        };
+        auto u8Edit = [&](const char* label, std::uint8_t& val) {
+            int v = static_cast<int>(val);
+            ImGuiMCP::SetNextItemWidth(150.f);
+            if (ImGuiMCP::InputInt(label, &v, 5, 20)) {
+                val = static_cast<std::uint8_t>(std::clamp(v, 0, 255));
+                dirty = true;
+            }
+        };
+
         if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_InGame", "In-game HUD").c_str())) {
             ImGuiMCP::SeparatorText(S::Get("HUD_Section_Layout", "Layout").c_str());
             ImGuiMCP::Spacing();
@@ -727,6 +751,57 @@ namespace {
             }
 
             ImGuiMCP::Spacing();
+            colorEdit(S::Get("HUD_Icon_TintColor", "Tint Color##icontintcolor").c_str(), st.iconTintColor);
+
+            ImGuiMCP::Spacing();
+            {
+                int sat = static_cast<int>(st.iconSaturation);
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::InputInt(S::Get("HUD_Icon_Saturation", "Saturation##iconsat").c_str(), &sat, 5, 20)) {
+                    st.iconSaturation = static_cast<std::uint8_t>(std::clamp(sat, 0, 255));
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                int bri = static_cast<int>(st.iconBrightness);
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::InputInt(S::Get("HUD_Icon_Brightness", "Brightness##iconbri").c_str(), &bri, 5, 20)) {
+                    st.iconBrightness = static_cast<std::uint8_t>(std::clamp(bri, 0, 255));
+                    dirty = true;
+                }
+            }
+
+            ImGuiMCP::Spacing();
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Text", "Text").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                bool tsEnabled = st.textShadowEnabled;
+                if (ImGuiMCP::Checkbox(S::Get("HUD_TextShadow_Enabled", "Text shadow##textshadowenabled").c_str(),
+                                       &tsEnabled)) {
+                    st.textShadowEnabled = tsEnabled;
+                    dirty = true;
+                }
+            }
+            if (st.textShadowEnabled) {
+                colorEdit(S::Get("HUD_TextShadow_Color", "Shadow Color##textshadowcol").c_str(), st.textShadowColor);
+                ImGuiMCP::SetNextItemWidth(100.f);
+                float tsx = st.textShadowOffsetX;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_TextShadow_OffsetX", "Offset X##textshadowox").c_str(), &tsx, 0.5f,
+                                         1.f, "%.1f")) {
+                    st.textShadowOffsetX = tsx;
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(100.f);
+                float tsy = st.textShadowOffsetY;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_TextShadow_OffsetY", "Offset Y##textshadowoy").c_str(), &tsy, 0.5f,
+                                         1.f, "%.1f")) {
+                    st.textShadowOffsetY = tsy;
+                    dirty = true;
+                }
+            }
+
+            ImGuiMCP::Spacing();
         }
 
         ImGuiMCP::Spacing();
@@ -808,6 +883,23 @@ namespace {
                     dirty = true;
                 }
             }
+
+            ImGuiMCP::Spacing();
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Overlay", "Overlay").c_str());
+            ImGuiMCP::Spacing();
+
+            colorEdit(S::Get("HUD_Overlay_Color", "Color##overlaycolor").c_str(), st.overlayColor);
+            {
+                float vs = st.vignetteStrength;
+                ImGuiMCP::SetNextItemWidth(200.f);
+                if (ImGuiMCP::SliderFloat(S::Get("HUD_Vignette_Strength", "Vignette##vignettestrength").c_str(), &vs,
+                                          0.f, 1.f, "%.2f")) {
+                    st.vignetteStrength = vs;
+                    dirty = true;
+                }
+            }
+
+            ImGuiMCP::Spacing();
         }
 
         ImGuiMCP::Spacing();
@@ -815,6 +907,34 @@ namespace {
         if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_SlotShape", "Slot Shape").c_str())) {
             ImGuiMCP::Spacing();
             DrawShapeEditor(dirty);
+
+            ImGuiMCP::Spacing();
+            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Corner", "Corner Style").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                const std::string cornerNames =
+                    S::Get("HUD_Corner_Round", "Round") + '\0' + S::Get("HUD_Corner_Square", "Square") + '\0' +
+                    S::Get("HUD_Corner_Notched", "Notched") + '\0' + S::Get("HUD_Corner_Chamfered", "Chamfered") + '\0';
+                int csi = static_cast<int>(st.slotCornerStyle);
+                ImGuiMCP::SetNextItemWidth(160.f);
+                if (ImGuiMCP::Combo(S::Get("HUD_CornerStyle_Label", "Style##cornerstyle").c_str(), &csi,
+                                    cornerNames.c_str())) {
+                    st.slotCornerStyle = static_cast<IntegratedMagic::CornerStyle>(csi);
+                    dirty = true;
+                }
+                if (st.slotCornerStyle != IntegratedMagic::CornerStyle::Square) {
+                    ImGuiMCP::SameLine();
+                    float cs = st.slotCornerSize;
+                    ImGuiMCP::SetNextItemWidth(120.f);
+                    if (ImGuiMCP::InputFloat(S::Get("HUD_CornerSize_Label", "Size##cornersize").c_str(), &cs, 1.f, 5.f,
+                                             "%.1f")) {
+                        st.slotCornerSize = std::clamp(cs, 0.f, 32.f);
+                        dirty = true;
+                    }
+                }
+            }
+
             ImGuiMCP::Spacing();
         }
 
@@ -991,39 +1111,70 @@ namespace {
         if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_Colors", "Colors").c_str())) {
             ImGuiMCP::Spacing();
 
-            auto colorEdit = [&](const char* label, std::uint32_t& col) {
-                float c[4];
-                c[0] = ((col >> 0) & 0xFF) / 255.f;
-                c[1] = ((col >> 8) & 0xFF) / 255.f;
-                c[2] = ((col >> 16) & 0xFF) / 255.f;
-                c[3] = ((col >> 24) & 0xFF) / 255.f;
-                if (ImGuiMCP::ColorEdit4(
-                        label, c,
-                        ImGuiMCP::ImGuiColorEditFlags_AlphaBar | ImGuiMCP::ImGuiColorEditFlags_AlphaPreview)) {
-                    col = (static_cast<std::uint32_t>(c[3] * 255.f + .5f) << 24) |
-                          (static_cast<std::uint32_t>(c[2] * 255.f + .5f) << 16) |
-                          (static_cast<std::uint32_t>(c[1] * 255.f + .5f) << 8) |
-                          static_cast<std::uint32_t>(c[0] * 255.f + .5f);
-                    dirty = true;
-                }
-            };
-            auto u8Edit = [&](const char* label, std::uint8_t& val) {
-                int v = static_cast<int>(val);
-                ImGuiMCP::SetNextItemWidth(150.f);
-                if (ImGuiMCP::InputInt(label, &v, 5, 20)) {
-                    val = static_cast<std::uint8_t>(std::clamp(v, 0, 255));
-                    dirty = true;
-                }
-            };
-
             ImGuiMCP::SeparatorText(S::Get("HUD_Colors_Slots", "Slots").c_str());
             colorEdit(S::Get("HUD_Color_BgActive", "Bg Active##slotbgactive").c_str(), st.slotBgActive);
             colorEdit(S::Get("HUD_Color_BgInactive", "Bg Inactive##slotbginactive").c_str(), st.slotBgInactive);
             colorEdit(S::Get("HUD_Color_RingInactive", "Ring Inactive##slotringinactive").c_str(), st.slotRingInactive);
             u8Edit(S::Get("HUD_Color_RingActiveAlpha", "Ring Active Alpha##slotringactivealpha").c_str(),
                    st.slotRingActiveAlpha);
+            {
+                float rw = st.slotRingWidth;
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::InputFloat(S::Get("HUD_Color_RingWidth", "Ring Width##slotrw").c_str(), &rw, 0.5f, 1.f,
+                                         "%.1f")) {
+                    st.slotRingWidth = std::clamp(rw, 0.f, 10.f);
+                    dirty = true;
+                }
+            }
+            colorEdit(S::Get("HUD_Color_OuterRing", "Outer Ring##slotouterring").c_str(), st.slotOuterRingColor);
+            {
+                float orw = st.slotOuterRingWidth;
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::InputFloat(S::Get("HUD_Color_OuterRingWidth", "Outer Ring Width##slotouterrw").c_str(),
+                                         &orw, 0.5f, 1.f, "%.1f")) {
+                    st.slotOuterRingWidth = std::clamp(orw, 0.f, 10.f);
+                    dirty = true;
+                }
+            }
             u8Edit(S::Get("HUD_Color_IconAlpha", "Icon Alpha##iconalpha").c_str(), st.iconAlpha);
             colorEdit(S::Get("HUD_Color_EmptySlot", "Empty Slot##emptyslotcolor").c_str(), st.emptySlotColor);
+
+            ImGuiMCP::Spacing();
+            ImGuiMCP::SeparatorText(S::Get("HUD_Colors_Gradient", "Background Gradient").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                const std::string gradNames = S::Get("HUD_Grad_None", "None") + '\0' +
+                                              S::Get("HUD_Grad_Radial", "Radial") + '\0' +
+                                              S::Get("HUD_Grad_Linear", "Linear") + '\0';
+                int gti = static_cast<int>(st.slotGradientType);
+                ImGuiMCP::SetNextItemWidth(140.f);
+                if (ImGuiMCP::Combo(S::Get("HUD_Grad_Type", "Type##gradtype").c_str(), &gti, gradNames.c_str())) {
+                    st.slotGradientType = static_cast<IntegratedMagic::GradientType>(gti);
+                    dirty = true;
+                }
+            }
+            if (st.slotGradientType != IntegratedMagic::GradientType::None) {
+                colorEdit(S::Get("HUD_Grad_Start", "Start Color##gradstart").c_str(), st.slotGradientStart);
+                colorEdit(S::Get("HUD_Grad_End", "End Color##gradend").c_str(), st.slotGradientEnd);
+                if (st.slotGradientType == IntegratedMagic::GradientType::Linear) {
+                    float ga = st.slotGradientAngle;
+                    ImGuiMCP::SetNextItemWidth(160.f);
+                    if (ImGuiMCP::SliderFloat(S::Get("HUD_Grad_Angle", "Angle##gradangle").c_str(), &ga, 0.f, 360.f,
+                                              "%.0f deg")) {
+                        st.slotGradientAngle = ga;
+                        dirty = true;
+                    }
+                } else {
+                    float gro = st.slotGradientRadialOffset;
+                    ImGuiMCP::SetNextItemWidth(160.f);
+                    if (ImGuiMCP::SliderFloat(S::Get("HUD_Grad_RadialOffset", "Center Offset##gradradial").c_str(),
+                                              &gro, -1.f, 1.f, "%.2f")) {
+                        st.slotGradientRadialOffset = gro;
+                        dirty = true;
+                    }
+                }
+            }
 
             ImGuiMCP::Spacing();
             ImGuiMCP::SeparatorText(S::Get("HUD_Colors_RingCenter", "Ring Center").c_str());

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -492,6 +492,7 @@ namespace {
             if (s_dragging == i && ImGuiMCP::IsMouseDown(0)) {
                 verts[i].x = std::clamp((mousePos.x - center.x) / kRadius, -1.f, 1.f);
                 verts[i].y = std::clamp((mousePos.y - center.y) / kRadius, -1.f, 1.f);
+                shape.useCustomShape = true;
                 dirty = true;
             }
 
@@ -515,12 +516,14 @@ namespace {
             } else {
                 verts.push_back({0.f, -1.f});
             }
+            shape.useCustomShape = true;
             dirty = true;
         }
         ImGuiMCP::SameLine();
         ImGuiMCP::BeginDisabled(verts.size() <= 3);
         if (ImGuiMCP::Button(S::Get("Shape_RemoveVertex", "- Vertex").c_str())) {
             verts.pop_back();
+            shape.useCustomShape = true;
             dirty = true;
         }
         ImGuiMCP::EndDisabled();
@@ -531,26 +534,31 @@ namespace {
 
         if (ImGuiMCP::Button(S::Get("Shape_Circle", "Circle").c_str())) {
             shape.SetCircle(16);
+            shape.useCustomShape = true;
             dirty = true;
         }
         ImGuiMCP::SameLine();
         if (ImGuiMCP::Button(S::Get("Shape_Square", "Square").c_str())) {
             shape.SetSquare();
+            shape.useCustomShape = true;
             dirty = true;
         }
         ImGuiMCP::SameLine();
         if (ImGuiMCP::Button(S::Get("Shape_Diamond", "Diamond").c_str())) {
             shape.SetDiamond();
+            shape.useCustomShape = true;
             dirty = true;
         }
         ImGuiMCP::SameLine();
         if (ImGuiMCP::Button(S::Get("Shape_Star5", "Star (5)").c_str())) {
             shape.SetStar(5, 0.45f);
+            shape.useCustomShape = true;
             dirty = true;
         }
         ImGuiMCP::SameLine();
         if (ImGuiMCP::Button(S::Get("Shape_Star6", "Star (6)").c_str())) {
             shape.SetStar(6, 0.45f);
+            shape.useCustomShape = true;
             dirty = true;
         }
     }
@@ -797,14 +805,14 @@ namespace {
             }
             if (st.textShadowEnabled) {
                 colorEdit(S::Get("HUD_TextShadow_Color", "Shadow Color##textshadowcol").c_str(), st.textShadowColor);
-                ImGuiMCP::SetNextItemWidth(100.f);
+                ImGuiMCP::SetNextItemWidth(150.f);
                 if (float tsx = st.textShadowOffsetX; ImGuiMCP::InputFloat(
                         S::Get("HUD_TextShadow_OffsetX", "Offset X##textshadowox").c_str(), &tsx, 0.5f, 1.f, "%.1f")) {
                     st.textShadowOffsetX = tsx;
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
-                ImGuiMCP::SetNextItemWidth(100.f);
+                ImGuiMCP::SetNextItemWidth(150.f);
                 float tsy = st.textShadowOffsetY;
                 if (ImGuiMCP::InputFloat(S::Get("HUD_TextShadow_OffsetY", "Offset Y##textshadowoy").c_str(), &tsy, 0.5f,
                                          1.f, "%.1f")) {
@@ -904,6 +912,9 @@ namespace {
                     dirty = true;
                 }
             }
+            if (st.vignetteStrength > 0.f) {
+                colorEdit(S::Get("HUD_Vignette_Color", "Vignette Color##vignettecolor").c_str(), st.vignetteColor);
+            }
 
             ImGuiMCP::Spacing();
         }
@@ -912,33 +923,54 @@ namespace {
 
         if (ImGuiMCP::CollapsingHeader(S::Get("HUD_Section_SlotShape", "Slot Shape").c_str())) {
             ImGuiMCP::Spacing();
-            DrawShapeEditor(dirty);
 
-            ImGuiMCP::Spacing();
-            ImGuiMCP::SeparatorText(S::Get("HUD_Section_Corner", "Corner Style").c_str());
-            ImGuiMCP::Spacing();
+            auto& shape = st.slotShape;
 
-            {
-                const std::string cornerNames =
-                    S::Get("HUD_Corner_Round", "Round") + '\0' + S::Get("HUD_Corner_Square", "Square") + '\0' +
-                    S::Get("HUD_Corner_Notched", "Notched") + '\0' + S::Get("HUD_Corner_Chamfered", "Chamfered") + '\0';
-                auto csi = static_cast<int>(std::to_underlying(st.slotCornerStyle));
-                ImGuiMCP::SetNextItemWidth(160.f);
-                if (ImGuiMCP::Combo(S::Get("HUD_CornerStyle_Label", "Style##cornerstyle").c_str(), &csi,
-                                    cornerNames.c_str())) {
-                    st.slotCornerStyle = static_cast<IntegratedMagic::CornerStyle>(csi);
-                    dirty = true;
-                }
-                if (st.slotCornerStyle != IntegratedMagic::CornerStyle::Square) {
-                    ImGuiMCP::SameLine();
-                    float cs = st.slotCornerSize;
-                    ImGuiMCP::SetNextItemWidth(150.f);
-                    if (ImGuiMCP::InputFloat(S::Get("HUD_CornerSize_Label", "Size##cornersize").c_str(), &cs, 1.f, 5.f,
-                                             "%.1f")) {
-                        st.slotCornerSize = std::clamp(cs, 0.f, 32.f);
+            if (!shape.useCustomShape) {
+                ImGuiMCP::SeparatorText(S::Get("HUD_Section_Corner", "Corner Style").c_str());
+                ImGuiMCP::Spacing();
+
+                {
+                    const std::string cornerNames = S::Get("HUD_Corner_Round", "Round") + '\0' +
+                                                    S::Get("HUD_Corner_Square", "Square") + '\0' +
+                                                    S::Get("HUD_Corner_Notched", "Notched") + '\0' +
+                                                    S::Get("HUD_Corner_Chamfered", "Chamfered") + '\0';
+                    auto csi = static_cast<int>(std::to_underlying(st.slotCornerStyle));
+                    ImGuiMCP::SetNextItemWidth(160.f);
+                    if (ImGuiMCP::Combo(S::Get("HUD_CornerStyle_Label", "Style##cornerstyle").c_str(), &csi,
+                                        cornerNames.c_str())) {
+                        st.slotCornerStyle = static_cast<IntegratedMagic::CornerStyle>(csi);
                         dirty = true;
                     }
+                    if (st.slotCornerStyle != IntegratedMagic::CornerStyle::Square) {
+                        ImGuiMCP::SameLine();
+                        float cs = st.slotCornerSize;
+                        ImGuiMCP::SetNextItemWidth(150.f);
+                        if (ImGuiMCP::InputFloat(S::Get("HUD_CornerSize_Label", "Size##cornersize").c_str(), &cs, 1.f,
+                                                 5.f, "%.1f")) {
+                            st.slotCornerSize = std::clamp(cs, 0.f, 32.f);
+                            dirty = true;
+                        }
+                    }
                 }
+
+                ImGuiMCP::Spacing();
+                if (ImGuiMCP::Button(S::Get("Shape_SwitchCustom", "Usar forma customizada...##switchcustom").c_str())) {
+                    shape.useCustomShape = true;
+                    dirty = true;
+                }
+            } else {
+                ImGuiMCP::SeparatorText(S::Get("Shape_CustomShape", "Forma Customizada").c_str());
+                ImGuiMCP::Spacing();
+
+                if (ImGuiMCP::Button(
+                        S::Get("Shape_SwitchCorner", "< Voltar para Corner Style##switchtocorner").c_str())) {
+                    shape.useCustomShape = false;
+                    dirty = true;
+                }
+                ImGuiMCP::Spacing();
+
+                DrawShapeEditor(dirty);
             }
 
             ImGuiMCP::Spacing();

--- a/src/UI/MENU.cpp
+++ b/src/UI/MENU.cpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <format>
 #include <string>
+#include <utility>
 
 #include "Config/Config.h"
 #include "Config/SpellType.h"
@@ -11,9 +12,9 @@
 #include "PCH.h"
 #include "Persistence/SpellSettingsDB.h"
 #include "SKSEMenuFramework.h"
-#include "Strings.h"
 #include "UI/HudManager.h"
 #include "UI/PolyFill.h"
+#include "UI/Strings.h"
 #include "UI/StyleConfig.h"
 
 namespace {
@@ -301,7 +302,7 @@ namespace {
                 IntegratedMagic::Strings::Get("Item_ButtonIcon_Keyboard", "Keyboard") + '\0' +
                 IntegratedMagic::Strings::Get("Item_ButtonIcon_PlayStation", "PlayStation") + '\0' +
                 IntegratedMagic::Strings::Get("Item_ButtonIcon_Xbox", "Xbox") + '\0';
-            int iconTypeIdx = static_cast<int>(st.buttonIconType);
+            auto iconTypeIdx = static_cast<int>(std::to_underlying(st.buttonIconType));
             ImGuiMCP::SetNextItemWidth(180.0f);
             if (ImGuiMCP::Combo(
                     IntegratedMagic::Strings::Get("Item_ButtonIconType", "Button icons##buttonicons").c_str(),
@@ -332,7 +333,7 @@ namespace {
                                            IntegratedMagic::Strings::Get("Mode_Automatic", "Automatic") + '\0';
 
         for (const auto& e : kTypeEntries) {
-            auto& d = cfg.spellTypeDefaults[static_cast<int>(e.type)];
+            auto& d = cfg.spellTypeDefaults[static_cast<int>(std::to_underlying(e.type))];
             const std::string label = IntegratedMagic::Strings::Get(e.labelKey, e.labelFallback);
 
             ImGuiMCP::PushID(e.labelKey);
@@ -340,7 +341,7 @@ namespace {
             ImGuiMCP::Text("%s", label.c_str());
             ImGuiMCP::SameLine(180.f);
 
-            int modeIdx = static_cast<int>(d.mode);
+            auto modeIdx = static_cast<int>(std::to_underlying(d.mode));
             ImGuiMCP::SetNextItemWidth(120.f);
             if (ImGuiMCP::Combo(IntegratedMagic::Strings::Get("Item_Mode", "Mode##mode").c_str(), &modeIdx,
                                 modeComboItems.c_str())) {
@@ -574,7 +575,7 @@ namespace {
             }
         };
         auto u8Edit = [&](const char* label, std::uint8_t& val) {
-            int v = static_cast<int>(val);
+            auto v = static_cast<int>(val);
             ImGuiMCP::SetNextItemWidth(150.f);
             if (ImGuiMCP::InputInt(label, &v, 5, 20)) {
                 val = static_cast<std::uint8_t>(std::clamp(v, 0, 255));
@@ -591,7 +592,7 @@ namespace {
                 const std::string layoutNames =
                     S::Get("HUD_Layout_Circular", "Circular") + '\0' + S::Get("HUD_Layout_Horizontal", "Horizontal") +
                     '\0' + S::Get("HUD_Layout_Vertical", "Vertical") + '\0' + S::Get("HUD_Layout_Grid", "Grid") + '\0';
-                int layoutIdx = static_cast<int>(st.hudLayout);
+                auto layoutIdx = static_cast<int>(std::to_underlying(st.hudLayout));
                 ImGuiMCP::SetNextItemWidth(150.f);
                 if (ImGuiMCP::Combo(S::Get("HUD_Layout_Label", "Layout##hudlayout").c_str(), &layoutIdx,
                                     layoutNames.c_str())) {
@@ -638,14 +639,14 @@ namespace {
             ImGuiMCP::SameLine(0.f, 16.f);
             ImGuiMCP::BeginGroup();
             ImGuiMCP::SetNextItemWidth(150.f);
-            float ox = st.hudOffsetX;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_OffsetX_Label", "X##hudox").c_str(), &ox, 1.f, 5.f, "%.0f")) {
+            if (float ox = st.hudOffsetX;
+                ImGuiMCP::InputFloat(S::Get("HUD_OffsetX_Label", "X##hudox").c_str(), &ox, 1.f, 5.f, "%.0f")) {
                 st.hudOffsetX = ox;
                 dirty = true;
             }
             ImGuiMCP::SetNextItemWidth(150.f);
-            float oy = st.hudOffsetY;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_OffsetY_Label", "Y##hudoy").c_str(), &oy, 1.f, 5.f, "%.0f")) {
+            if (float oy = st.hudOffsetY;
+                ImGuiMCP::InputFloat(S::Get("HUD_OffsetY_Label", "Y##hudoy").c_str(), &oy, 1.f, 5.f, "%.0f")) {
                 st.hudOffsetY = oy;
                 dirty = true;
             }
@@ -658,41 +659,37 @@ namespace {
 
             {
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float sr = st.slotRadius;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_SlotRadius_Label", "Radius##slotradius").c_str(), &sr, 1.f, 5.f,
-                                         "%.1f")) {
+                if (float sr = st.slotRadius; ImGuiMCP::InputFloat(
+                        S::Get("HUD_SlotRadius_Label", "Radius##slotradius").c_str(), &sr, 1.f, 5.f, "%.1f")) {
                     st.slotRadius = sr;
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float rw = st.slotRingWidth;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_RingWidth_Label", "Ring Width##ringwidth").c_str(), &rw, 0.5f, 1.f,
-                                         "%.1f")) {
+                if (float rw = st.slotRingWidth; ImGuiMCP::InputFloat(
+                        S::Get("HUD_RingWidth_Label", "Ring Width##ringwidth").c_str(), &rw, 0.5f, 1.f, "%.1f")) {
                     st.slotRingWidth = std::max(0.f, rw);
                     dirty = true;
                 }
                 ImGuiMCP::Spacing();
 
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float as = st.slotActiveScale;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_ActiveScale_Label", "Active##activescale").c_str(), &as, 0.05f,
-                                         0.1f, "%.2f")) {
+                if (float as = st.slotActiveScale; ImGuiMCP::InputFloat(
+                        S::Get("HUD_ActiveScale_Label", "Active##activescale").c_str(), &as, 0.05f, 0.1f, "%.2f")) {
                     st.slotActiveScale = as;
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float ms = st.slotModifierScale;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_ModifierScale_Label", "Modifier##modscale").c_str(), &ms, 0.05f,
-                                         0.1f, "%.2f")) {
+                if (float ms = st.slotModifierScale; ImGuiMCP::InputFloat(
+                        S::Get("HUD_ModifierScale_Label", "Modifier##modscale").c_str(), &ms, 0.05f, 0.1f, "%.2f")) {
                     st.slotModifierScale = ms;
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float ns = st.slotNeighborScale;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_NeighborScale_Label", "Neighbor##neighborscale").c_str(), &ns,
+                if (float ns = st.slotNeighborScale;
+                    ImGuiMCP::InputFloat(S::Get("HUD_NeighborScale_Label", "Neighbor##neighborscale").c_str(), &ns,
                                          0.05f, 0.1f, "%.2f")) {
                     st.slotNeighborScale = ns;
                     dirty = true;
@@ -700,9 +697,8 @@ namespace {
                 ImGuiMCP::Spacing();
 
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float et = st.slotExpandTime;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_ExpandTime_Label", "Expand##expandtime").c_str(), &et, 0.01f,
-                                         0.05f, "%.2f")) {
+                if (float et = st.slotExpandTime; ImGuiMCP::InputFloat(
+                        S::Get("HUD_ExpandTime_Label", "Expand##expandtime").c_str(), &et, 0.01f, 0.05f, "%.2f")) {
                     st.slotExpandTime = std::max(0.f, et);
                     dirty = true;
                 }
@@ -734,9 +730,8 @@ namespace {
 
             {
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float isf = st.iconSizeFactor;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_IconSize_Label", "Size##iconsizefactor").c_str(), &isf, 0.05f,
-                                         0.1f, "%.2f")) {
+                if (float isf = st.iconSizeFactor; ImGuiMCP::InputFloat(
+                        S::Get("HUD_IconSize_Label", "Size##iconsizefactor").c_str(), &isf, 0.05f, 0.1f, "%.2f")) {
                     st.iconSizeFactor = std::clamp(isf, 0.1f, 2.f);
                     dirty = true;
                 }
@@ -755,14 +750,14 @@ namespace {
 
             ImGuiMCP::Spacing();
             {
-                int sat = static_cast<int>(st.iconSaturation);
+                auto sat = static_cast<int>(st.iconSaturation);
                 ImGuiMCP::SetNextItemWidth(150.f);
                 if (ImGuiMCP::InputInt(S::Get("HUD_Icon_Saturation", "Saturation##iconsat").c_str(), &sat, 5, 20)) {
                     st.iconSaturation = static_cast<std::uint8_t>(std::clamp(sat, 0, 255));
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
-                int bri = static_cast<int>(st.iconBrightness);
+                auto bri = static_cast<int>(st.iconBrightness);
                 ImGuiMCP::SetNextItemWidth(150.f);
                 if (ImGuiMCP::InputInt(S::Get("HUD_Icon_Brightness", "Brightness##iconbri").c_str(), &bri, 5, 20)) {
                     st.iconBrightness = static_cast<std::uint8_t>(std::clamp(bri, 0, 255));
@@ -785,9 +780,8 @@ namespace {
             if (st.textShadowEnabled) {
                 colorEdit(S::Get("HUD_TextShadow_Color", "Shadow Color##textshadowcol").c_str(), st.textShadowColor);
                 ImGuiMCP::SetNextItemWidth(100.f);
-                float tsx = st.textShadowOffsetX;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_TextShadow_OffsetX", "Offset X##textshadowox").c_str(), &tsx, 0.5f,
-                                         1.f, "%.1f")) {
+                if (float tsx = st.textShadowOffsetX; ImGuiMCP::InputFloat(
+                        S::Get("HUD_TextShadow_OffsetX", "Offset X##textshadowox").c_str(), &tsx, 0.5f, 1.f, "%.1f")) {
                     st.textShadowOffsetX = tsx;
                     dirty = true;
                 }
@@ -813,7 +807,7 @@ namespace {
                 const std::string popupLayoutNames =
                     S::Get("HUD_Layout_Circular", "Circular") + '\0' + S::Get("HUD_Layout_Horizontal", "Horizontal") +
                     '\0' + S::Get("HUD_Layout_Vertical", "Vertical") + '\0' + S::Get("HUD_Layout_Grid", "Grid") + '\0';
-                int popupLayoutIdx = static_cast<int>(st.popupLayout);
+                auto popupLayoutIdx = static_cast<int>(std::to_underlying(st.popupLayout));
                 ImGuiMCP::SetNextItemWidth(180.f);
                 if (ImGuiMCP::Combo(S::Get("HUD_PopupLayout_Label", "Layout##popuplayout").c_str(), &popupLayoutIdx,
                                     popupLayoutNames.c_str())) {
@@ -825,42 +819,37 @@ namespace {
 
             {
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float psr = st.popupSlotRadius;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupSlotR_Label", "Slot R##popupslotradius").c_str(), &psr, 1.f,
-                                         5.f, "%.0f")) {
+                if (float psr = st.popupSlotRadius; ImGuiMCP::InputFloat(
+                        S::Get("HUD_PopupSlotR_Label", "Slot R##popupslotradius").c_str(), &psr, 1.f, 5.f, "%.0f")) {
                     st.popupSlotRadius = std::max(1.f, psr);
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float prr = st.popupRingRadius;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupRingR_Label", "Ring R##popupringradius").c_str(), &prr, 1.f,
-                                         5.f, "%.0f")) {
+                if (float prr = st.popupRingRadius; ImGuiMCP::InputFloat(
+                        S::Get("HUD_PopupRingR_Label", "Ring R##popupringradius").c_str(), &prr, 1.f, 5.f, "%.0f")) {
                     st.popupRingRadius = std::max(1.f, prr);
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float psg = st.popupSlotGap;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupGap_Label", "Gap##popupslotgap").c_str(), &psg, 1.f, 5.f,
-                                         "%.0f")) {
+                if (float psg = st.popupSlotGap; ImGuiMCP::InputFloat(
+                        S::Get("HUD_PopupGap_Label", "Gap##popupslotgap").c_str(), &psg, 1.f, 5.f, "%.0f")) {
                     st.popupSlotGap = psg;
                     dirty = true;
                 }
                 ImGuiMCP::Spacing();
 
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float mww = st.modeWidgetW;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_ModeWidgetW_Label", "Widget W##modewidgetw").c_str(), &mww, 1.f,
-                                         5.f, "%.0f")) {
+                if (float mww = st.modeWidgetW; ImGuiMCP::InputFloat(
+                        S::Get("HUD_ModeWidgetW_Label", "Widget W##modewidgetw").c_str(), &mww, 1.f, 5.f, "%.0f")) {
                     st.modeWidgetW = std::max(1.f, mww);
                     dirty = true;
                 }
                 ImGuiMCP::SameLine();
                 ImGuiMCP::SetNextItemWidth(150.f);
-                int oa = static_cast<int>(st.overlayAlpha);
-                if (ImGuiMCP::InputInt(S::Get("HUD_OverlayAlpha_Label", "Overlay Alpha##overlayalpha").c_str(), &oa, 5,
-                                       20)) {
+                if (auto oa = static_cast<int>(st.overlayAlpha); ImGuiMCP::InputInt(
+                        S::Get("HUD_OverlayAlpha_Label", "Overlay Alpha##overlayalpha").c_str(), &oa, 5, 20)) {
                     st.overlayAlpha = static_cast<std::uint8_t>(std::clamp(oa, 0, 255));
                     dirty = true;
                 }
@@ -868,9 +857,8 @@ namespace {
                 ImGuiMCP::Spacing();
 
                 ImGuiMCP::SetNextItemWidth(150.f);
-                float pox = st.popupOffsetX;
-                if (ImGuiMCP::InputFloat(S::Get("HUD_PopupOffsetX_Label", "Offset X##popupox").c_str(), &pox, 1.f, 5.f,
-                                         "%.0f")) {
+                if (float pox = st.popupOffsetX; ImGuiMCP::InputFloat(
+                        S::Get("HUD_PopupOffsetX_Label", "Offset X##popupox").c_str(), &pox, 1.f, 5.f, "%.0f")) {
                     st.popupOffsetX = pox;
                     dirty = true;
                 }
@@ -916,7 +904,7 @@ namespace {
                 const std::string cornerNames =
                     S::Get("HUD_Corner_Round", "Round") + '\0' + S::Get("HUD_Corner_Square", "Square") + '\0' +
                     S::Get("HUD_Corner_Notched", "Notched") + '\0' + S::Get("HUD_Corner_Chamfered", "Chamfered") + '\0';
-                int csi = static_cast<int>(st.slotCornerStyle);
+                auto csi = static_cast<int>(std::to_underlying(st.slotCornerStyle));
                 ImGuiMCP::SetNextItemWidth(160.f);
                 if (ImGuiMCP::Combo(S::Get("HUD_CornerStyle_Label", "Style##cornerstyle").c_str(), &csi,
                                     cornerNames.c_str())) {
@@ -926,7 +914,7 @@ namespace {
                 if (st.slotCornerStyle != IntegratedMagic::CornerStyle::Square) {
                     ImGuiMCP::SameLine();
                     float cs = st.slotCornerSize;
-                    ImGuiMCP::SetNextItemWidth(120.f);
+                    ImGuiMCP::SetNextItemWidth(150.f);
                     if (ImGuiMCP::InputFloat(S::Get("HUD_CornerSize_Label", "Size##cornersize").c_str(), &cs, 1.f, 5.f,
                                              "%.1f")) {
                         st.slotCornerSize = std::clamp(cs, 0.f, 32.f);
@@ -946,7 +934,7 @@ namespace {
             const std::string modVisNames = S::Get("Item_ModVis_Never", "Never") + '\0' +
                                             S::Get("Item_ModVis_Always", "Always") + '\0' +
                                             S::Get("Item_ModVis_HideOnPress", "Hide on press") + '\0';
-            int modVisIdx = static_cast<int>(st.modifierWidgetVisibility);
+            auto modVisIdx = static_cast<int>(std::to_underlying(st.modifierWidgetVisibility));
             ImGuiMCP::SetNextItemWidth(180.f);
             if (ImGuiMCP::Combo(S::Get("Item_ModifierVisibility", "Visibility##modvis").c_str(), &modVisIdx,
                                 modVisNames.c_str())) {
@@ -956,17 +944,15 @@ namespace {
             ImGuiMCP::Spacing();
 
             ImGuiMCP::SetNextItemWidth(150.f);
-            float mr = st.modifierWidgetRadius;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_ModWidget_Radius", "Radius##modwidgetradius").c_str(), &mr, 1.f, 5.f,
-                                     "%.1f")) {
+            if (float mr = st.modifierWidgetRadius; ImGuiMCP::InputFloat(
+                    S::Get("HUD_ModWidget_Radius", "Radius##modwidgetradius").c_str(), &mr, 1.f, 5.f, "%.1f")) {
                 st.modifierWidgetRadius = std::max(1.f, mr);
                 dirty = true;
             }
             ImGuiMCP::SameLine();
             ImGuiMCP::SetNextItemWidth(150.f);
-            float mox = st.modifierWidgetOffsetX;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_ModWidget_OffsetX", "X##modwidgetox").c_str(), &mox, 1.f, 5.f,
-                                     "%.0f")) {
+            if (float mox = st.modifierWidgetOffsetX; ImGuiMCP::InputFloat(
+                    S::Get("HUD_ModWidget_OffsetX", "X##modwidgetox").c_str(), &mox, 1.f, 5.f, "%.0f")) {
                 st.modifierWidgetOffsetX = mox;
                 dirty = true;
             }
@@ -988,7 +974,7 @@ namespace {
             const std::string lblVisNames = S::Get("HUD_BtnLbl_Never", "Never") + '\0' +
                                             S::Get("HUD_BtnLbl_Always", "Always") + '\0' +
                                             S::Get("HUD_BtnLbl_OnModifier", "On modifier") + '\0';
-            int lblVisIdx = static_cast<int>(st.buttonLabelVisibility);
+            auto lblVisIdx = static_cast<int>(std::to_underlying(st.buttonLabelVisibility));
             ImGuiMCP::SetNextItemWidth(180.f);
             if (ImGuiMCP::Combo(S::Get("HUD_BtnLbl_Visibility", "Visibility##btnlblvis").c_str(), &lblVisIdx,
                                 lblVisNames.c_str())) {
@@ -1060,39 +1046,36 @@ namespace {
             ImGuiMCP::Spacing();
 
             ImGuiMCP::SetNextItemWidth(150.f);
-            float iconSz = st.buttonLabelIconSize;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_IconSize", "Icon size##btnlblsz").c_str(), &iconSz, 1.f, 5.f,
-                                     "%.0f")) {
+            if (float iconSz = st.buttonLabelIconSize; ImGuiMCP::InputFloat(
+                    S::Get("HUD_BtnLbl_IconSize", "Icon size##btnlblsz").c_str(), &iconSz, 1.f, 5.f, "%.0f")) {
                 st.buttonLabelIconSize = std::max(4.f, iconSz);
                 dirty = true;
             }
             ImGuiMCP::SameLine();
             ImGuiMCP::SetNextItemWidth(150.f);
-            float iconSpc = st.buttonLabelIconSpacing;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_IconSpacing", "Spacing##btnlblspc").c_str(), &iconSpc, 1.f, 5.f,
-                                     "%.0f")) {
+            if (float iconSpc = st.buttonLabelIconSpacing; ImGuiMCP::InputFloat(
+                    S::Get("HUD_BtnLbl_IconSpacing", "Spacing##btnlblspc").c_str(), &iconSpc, 1.f, 5.f, "%.0f")) {
                 st.buttonLabelIconSpacing = iconSpc;
                 dirty = true;
             }
             ImGuiMCP::SameLine();
             ImGuiMCP::SetNextItemWidth(150.f);
-            float margin = st.buttonLabelMargin;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_Margin", "Margin##btnlblmar").c_str(), &margin, 1.f, 5.f,
-                                     "%.0f")) {
+            if (float margin = st.buttonLabelMargin; ImGuiMCP::InputFloat(
+                    S::Get("HUD_BtnLbl_Margin", "Margin##btnlblmar").c_str(), &margin, 1.f, 5.f, "%.0f")) {
                 st.buttonLabelMargin = margin;
                 dirty = true;
             }
 
             ImGuiMCP::SetNextItemWidth(150.f);
-            float ox2 = st.buttonLabelOffsetX;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_OffsetX", "X##btnlblox").c_str(), &ox2, 1.f, 5.f, "%.0f")) {
+            if (float ox2 = st.buttonLabelOffsetX;
+                ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_OffsetX", "X##btnlblox").c_str(), &ox2, 1.f, 5.f, "%.0f")) {
                 st.buttonLabelOffsetX = ox2;
                 dirty = true;
             }
             ImGuiMCP::SameLine();
             ImGuiMCP::SetNextItemWidth(150.f);
-            float oy2 = st.buttonLabelOffsetY;
-            if (ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_OffsetY", "Y##btnlbloy").c_str(), &oy2, 1.f, 5.f, "%.0f")) {
+            if (float oy2 = st.buttonLabelOffsetY;
+                ImGuiMCP::InputFloat(S::Get("HUD_BtnLbl_OffsetY", "Y##btnlbloy").c_str(), &oy2, 1.f, 5.f, "%.0f")) {
                 st.buttonLabelOffsetY = oy2;
                 dirty = true;
             }
@@ -1115,14 +1098,22 @@ namespace {
             colorEdit(S::Get("HUD_Color_BgActive", "Bg Active##slotbgactive").c_str(), st.slotBgActive);
             colorEdit(S::Get("HUD_Color_BgInactive", "Bg Inactive##slotbginactive").c_str(), st.slotBgInactive);
             colorEdit(S::Get("HUD_Color_RingInactive", "Ring Inactive##slotringinactive").c_str(), st.slotRingInactive);
+            colorEdit(S::Get("HUD_Color_RingActive", "Ring Active##slotringactive").c_str(), st.slotRingActive);
             u8Edit(S::Get("HUD_Color_RingActiveAlpha", "Ring Active Alpha##slotringactivealpha").c_str(),
                    st.slotRingActiveAlpha);
             {
-                float rw = st.slotRingWidth;
                 ImGuiMCP::SetNextItemWidth(150.f);
-                if (ImGuiMCP::InputFloat(S::Get("HUD_Color_RingWidth", "Ring Width##slotrw").c_str(), &rw, 0.5f, 1.f,
-                                         "%.1f")) {
+                if (float rw = st.slotRingWidth; ImGuiMCP::InputFloat(
+                        S::Get("HUD_Color_RingWidth", "Ring Width##slotrw").c_str(), &rw, 0.5f, 1.f, "%.1f")) {
                     st.slotRingWidth = std::clamp(rw, 0.f, 10.f);
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                ImGuiMCP::SetNextItemWidth(150.f);
+                float rwa = st.slotRingWidthActive;
+                if (ImGuiMCP::InputFloat(S::Get("HUD_Color_RingWidthActive", "Active Width##slotringwa").c_str(), &rwa,
+                                         0.5f, 1.f, "%.1f")) {
+                    st.slotRingWidthActive = std::clamp(rwa, 0.f, 10.f);
                     dirty = true;
                 }
             }
@@ -1147,7 +1138,7 @@ namespace {
                 const std::string gradNames = S::Get("HUD_Grad_None", "None") + '\0' +
                                               S::Get("HUD_Grad_Radial", "Radial") + '\0' +
                                               S::Get("HUD_Grad_Linear", "Linear") + '\0';
-                int gti = static_cast<int>(st.slotGradientType);
+                auto gti = static_cast<int>(std::to_underlying(st.slotGradientType));
                 ImGuiMCP::SetNextItemWidth(140.f);
                 if (ImGuiMCP::Combo(S::Get("HUD_Grad_Type", "Type##gradtype").c_str(), &gti, gradNames.c_str())) {
                     st.slotGradientType = static_cast<IntegratedMagic::GradientType>(gti);
@@ -1180,6 +1171,60 @@ namespace {
             ImGuiMCP::SeparatorText(S::Get("HUD_Colors_RingCenter", "Ring Center").c_str());
             colorEdit(S::Get("HUD_Color_RingCenterFill", "Fill##ringcenterfill").c_str(), st.ringCenterFill);
             colorEdit(S::Get("HUD_Color_RingCenterBorder", "Border##ringcenterborder").c_str(), st.ringCenterBorder);
+
+            ImGuiMCP::Spacing();
+            ImGuiMCP::SeparatorText(S::Get("HUD_Colors_Glow", "Glow").c_str());
+            ImGuiMCP::Spacing();
+
+            {
+                const std::string glowStyleNames = S::Get("HUD_Glow_Ring", "Ring") + '\0' +
+                                                   S::Get("HUD_Glow_Fill", "Fill") + '\0' +
+                                                   S::Get("HUD_Glow_Both", "Both") + '\0';
+                auto gsi = static_cast<int>(std::to_underlying(st.glowStyle));
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::Combo(S::Get("HUD_Glow_Style", "Style##glowstyle").c_str(), &gsi,
+                                    glowStyleNames.c_str())) {
+                    st.glowStyle = static_cast<IntegratedMagic::GlowStyle>(gsi);
+                    dirty = true;
+                }
+            }
+
+            {
+                auto gl = static_cast<int>(st.glowLayers);
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::InputInt(S::Get("HUD_Glow_Layers", "Layers##glowlayers").c_str(), &gl, 1, 1)) {
+                    st.glowLayers = static_cast<std::uint8_t>(std::clamp(gl, 1, 5));
+                    dirty = true;
+                }
+                ImGuiMCP::SameLine();
+                float gr = st.glowRadius;
+                ImGuiMCP::SetNextItemWidth(150.f);
+                if (ImGuiMCP::InputFloat(S::Get("HUD_Glow_Radius", "Radius##glowradius").c_str(), &gr, 0.5f, 1.f,
+                                         "%.1f")) {
+                    st.glowRadius = std::clamp(gr, 0.5f, 20.f);
+                    dirty = true;
+                }
+            }
+
+            {
+                float gi = st.glowIntensity;
+                ImGuiMCP::SetNextItemWidth(180.f);
+                if (ImGuiMCP::SliderFloat(S::Get("HUD_Glow_Intensity", "Intensity##glowintensity").c_str(), &gi, 0.f,
+                                          2.f, "%.2f")) {
+                    st.glowIntensity = gi;
+                    dirty = true;
+                }
+            }
+
+            {
+                float ps = st.pulseSpeed;
+                ImGuiMCP::SetNextItemWidth(180.f);
+                if (ImGuiMCP::SliderFloat(S::Get("HUD_Glow_PulseSpeed", "Pulse Speed##pulsespeed").c_str(), &ps, 0.f,
+                                          20.f, "%.1f")) {
+                    st.pulseSpeed = ps;
+                    dirty = true;
+                }
+            }
 
             ImGuiMCP::Spacing();
             ImGuiMCP::SeparatorText(S::Get("HUD_Colors_Schools", "School Colors").c_str());

--- a/src/UI/PolyFill.h
+++ b/src/UI/PolyFill.h
@@ -11,9 +11,29 @@ namespace IntegratedMagic::PolyFill {
         float cx, cy;
     };
 
+    inline bool IsConvex(const std::vector<SlotShapeVertex>& verts) {
+        const int n = static_cast<int>(verts.size());
+        if (n < 3) return false;
+        int sign = 0;
+        for (int i = 0; i < n; ++i) {
+            const auto& a = verts[i];
+            const auto& b = verts[(i + 1) % n];
+            const auto& c = verts[(i + 2) % n];
+            const float cross = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x);
+            if (cross > 0.f) {
+                if (sign < 0) return false;
+                sign = 1;
+            } else if (cross < 0.f) {
+                if (sign > 0) return false;
+                sign = -1;
+            }
+        }
+        return true;
+    }
+
     inline std::vector<Triangle> Triangulate(const std::vector<SlotShapeVertex>& verts, float centerX, float centerY,
                                              float r) {
-        const auto n = static_cast<int>(verts.size());
+        const int n = static_cast<int>(verts.size());
         if (n < 3) return {};
 
         float cx = 0.f, cy = 0.f;
@@ -33,4 +53,5 @@ namespace IntegratedMagic::PolyFill {
         }
         return tris;
     }
+
 }

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -79,7 +79,7 @@ namespace IntegratedMagic::HUD::PopupDrawer {
 
         void FillSlotShapeHighlight(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
             const auto& shape = StyleConfig::Get().slotShape;
-            if (shape.vertices.size() >= 3) {
+            if (shape.useCustomShape && shape.vertices.size() >= 3) {
                 if (PolyFill::IsConvex(shape.vertices)) {
                     for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
                     dl->PathFillConvex(col);
@@ -94,7 +94,7 @@ namespace IntegratedMagic::HUD::PopupDrawer {
 
         void FillSlotHalfHighlight(ImDrawList* dl, ImVec2 center, float r, bool rightHalf, ImU32 col) {
             const auto& shape = StyleConfig::Get().slotShape;
-            if (shape.vertices.size() >= 3) {
+            if (shape.useCustomShape && shape.vertices.size() >= 3) {
                 const float sign = rightHalf ? 1.f : -1.f;
                 std::vector<SlotShapeVertex> clipped;
                 const auto& verts = shape.vertices;
@@ -163,8 +163,9 @@ namespace IntegratedMagic::HUD::PopupDrawer {
         bg->AddRectFilled({0.f, 0.f}, {displaySize.x, displaySize.y}, baseOverlay, 0.f, 0);
 
         if (st.vignetteStrength > 0.f) {
-            const ImU32 vigFull = IM_COL32(0, 0, 0, static_cast<int>(st.vignetteStrength * 220.f));
-            const ImU32 vigZero = IM_COL32(0, 0, 0, 0);
+            const ImU32 vigRGB = st.vignetteColor & 0x00FFFFFFu;
+            const ImU32 vigFull = vigRGB | (static_cast<ImU32>(static_cast<int>(st.vignetteStrength * 220.f)) << 24);
+            const ImU32 vigZero = vigRGB | 0x00000000u;
             const float vs = std::min(displaySize.x, displaySize.y) * 0.35f;
 
             bg->AddRectFilledMultiColor({0.f, 0.f}, {vs, displaySize.y}, vigFull, vigZero, vigZero, vigFull);

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -5,20 +5,22 @@
 #include <cmath>
 #include <numbers>
 #include <string>
+#include <vector>
 
 #include "Config/Config.h"
 #include "Config/Slots.h"
-#include "HudState.h"
 #include "PCH.h"
 #include "Persistence/SpellSettingsDB.h"
-#include "SlotDrawer.h"
 #include "State/Assign.h"
 #include "State/SpellClassify.h"
 #include "State/State.h"
-#include "Strings.h"
 #include "UI/HoveredForm.h"
+#include "UI/HudState.h"
+#include "UI/HudTextUtil.h"
 #include "UI/PolyFill.h"
+#include "UI/SlotDrawer.h"
 #include "UI/SlotLayout.h"
+#include "UI/Strings.h"
 #include "UI/StyleConfig.h"
 #include "UI/TextureManager.h"
 
@@ -342,20 +344,27 @@ namespace IntegratedMagic::HUD::PopupDrawer {
                 const RE::FormID dispShoutID = shoutID ? shoutID : (slotIs2H ? lID : 0);
 
                 SlotDrawer::DrawSlotVisual(dl, center, st.popupSlotRadius, activeSlot == i, slotIs2H ? nullptr : rSp,
-                                           slotIs2H ? nullptr : lSp, dispShoutID);
+                                           slotIs2H ? nullptr : lSp, dispShoutID, true);
                 SlotDrawer::DrawSlotHotkeyIcons(dl, center, st.popupSlotRadius, i);
 
-                if (shoutID || slotIs2H) {
-                    auto* f = RE::TESForm::LookupByID(dispShoutID);
-                    const char* name = f ? f->GetName() : "???";
-                    const char* prefix = shoutID ? Strings::Get("Popup_ShoutPrefix", "[S]").c_str() : "[2H]";
-                    ImGui::SetCursorScreenPos({center.x - st.popupSlotRadius, center.y - st.popupSlotRadius - 16.f});
-                    ImGui::TextDisabled("%s %s", prefix, name);
-                } else if (rSp || lSp) {
-                    const std::string label =
-                        std::string(lSp ? lSp->GetName() : "---") + " | " + (rSp ? rSp->GetName() : "---");
-                    ImGui::SetCursorScreenPos({center.x - st.popupSlotRadius, center.y - st.popupSlotRadius - 16.f});
-                    ImGui::TextDisabled("%s", label.c_str());
+                {
+                    const float iconReserve =
+                        (st.buttonLabelVisibility != IntegratedMagic::ButtonLabelVisibility::Never)
+                            ? (st.buttonLabelIconSize + st.buttonLabelMargin + 5.f)
+                            : 0.f;
+                    const float slotTop = center.y - st.popupSlotRadius - iconReserve;
+
+                    if (shoutID || slotIs2H) {
+                        auto* f = RE::TESForm::LookupByID(dispShoutID);
+                        const std::string name = f ? f->GetName() : "???";
+                        DrawWrappedLabelAbove(name.c_str(), center.x - st.popupSlotRadius, st.popupSlotRadius * 2.f,
+                                              slotTop, 4.f, true);
+                    } else if (rSp || lSp) {
+                        const float halfWidth = st.popupSlotRadius;
+                        if (lSp)
+                            DrawWrappedLabelAbove(lSp->GetName(), center.x - st.popupSlotRadius, halfWidth, slotTop);
+                        if (rSp) DrawWrappedLabelAbove(rSp->GetName(), center.x, halfWidth, slotTop);
+                    }
                 }
 
                 {

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -80,8 +80,14 @@ namespace IntegratedMagic::HUD::PopupDrawer {
         void FillSlotShapeHighlight(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
             const auto& shape = StyleConfig::Get().slotShape;
             if (shape.vertices.size() >= 3) {
-                for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
-                    dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
+                if (PolyFill::IsConvex(shape.vertices)) {
+                    for (const auto& v : shape.vertices)
+                        dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
+                    dl->PathFillConvex(col);
+                } else {
+                    for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
+                        dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
+                }
             } else {
                 dl->AddCircleFilled(center, r, col, 48);
             }

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -300,10 +300,11 @@ namespace IntegratedMagic::HUD::PopupDrawer {
         const float popupHalfX = bh.x + kGlowPad + st.modeWidgetW + 12.f;
         const float popupHalfY = bh.y + kGlowPad + st.modeWidgetW + 12.f;
         const ImVec2 popupSize = {popupHalfX * 2.f, popupHalfY * 2.f + 48.f};
-        const ImVec2 popupPos = {io.DisplaySize.x * 0.5f - popupSize.x * 0.5f,
-                                 io.DisplaySize.y * 0.5f - popupSize.y * 0.5f};
+        const ImVec2 popupPos = {io.DisplaySize.x * 0.5f - popupSize.x * 0.5f + st.popupOffsetX,
+                                 io.DisplaySize.y * 0.5f - popupSize.y * 0.5f + st.popupOffsetY};
         const ImVec2 popupEnd = {popupPos.x + popupSize.x, popupPos.y + popupSize.y};
-        const ImVec2 ringCenter = {io.DisplaySize.x * 0.5f, io.DisplaySize.y * 0.5f};
+        const ImVec2 ringCenter = {io.DisplaySize.x * 0.5f + st.popupOffsetX,
+                                   io.DisplaySize.y * 0.5f + st.popupOffsetY};
 
         LayoutVec2 relPos[SlotLayout::kMaxSlots]{};
         SlotLayout::Compute(st.popupLayout, n, st.popupSlotRadius, dynPopupR, st.popupSlotGap, st.gridColumns, relPos);

--- a/src/UI/Popupdrawer.cpp
+++ b/src/UI/Popupdrawer.cpp
@@ -81,8 +81,7 @@ namespace IntegratedMagic::HUD::PopupDrawer {
             const auto& shape = StyleConfig::Get().slotShape;
             if (shape.vertices.size() >= 3) {
                 if (PolyFill::IsConvex(shape.vertices)) {
-                    for (const auto& v : shape.vertices)
-                        dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
+                    for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
                     dl->PathFillConvex(col);
                 } else {
                     for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
@@ -157,8 +156,27 @@ namespace IntegratedMagic::HUD::PopupDrawer {
     }
 
     void DrawOverlayAndCursor(ImVec2 displaySize, ImVec2 cursorPos) {
+        const auto& st = Style();
         ImDrawList* bg = ImGui::GetBackgroundDrawList();
-        bg->AddRectFilled({0.f, 0.f}, {displaySize.x, displaySize.y}, IM_COL32(0, 0, 0, Style().overlayAlpha), 0.f, 0);
+
+        const ImU32 baseOverlay = (static_cast<ImU32>(st.overlayAlpha) << 24) | (st.overlayColor & 0x00FFFFFFu);
+        bg->AddRectFilled({0.f, 0.f}, {displaySize.x, displaySize.y}, baseOverlay, 0.f, 0);
+
+        if (st.vignetteStrength > 0.f) {
+            const ImU32 vigFull = IM_COL32(0, 0, 0, static_cast<int>(st.vignetteStrength * 220.f));
+            const ImU32 vigZero = IM_COL32(0, 0, 0, 0);
+            const float vs = std::min(displaySize.x, displaySize.y) * 0.35f;
+
+            bg->AddRectFilledMultiColor({0.f, 0.f}, {vs, displaySize.y}, vigFull, vigZero, vigZero, vigFull);
+
+            bg->AddRectFilledMultiColor({displaySize.x - vs, 0.f}, {displaySize.x, displaySize.y}, vigZero, vigFull,
+                                        vigFull, vigZero);
+
+            bg->AddRectFilledMultiColor({0.f, 0.f}, {displaySize.x, vs}, vigFull, vigFull, vigZero, vigZero);
+
+            bg->AddRectFilledMultiColor({0.f, displaySize.y - vs}, {displaySize.x, displaySize.y}, vigZero, vigZero,
+                                        vigFull, vigFull);
+        }
 
         ImDrawList* fg = ImGui::GetForegroundDrawList();
         const ImVec2 pts[3] = {{cursorPos.x, cursorPos.y},

--- a/src/UI/SlotDrawer.h
+++ b/src/UI/SlotDrawer.h
@@ -9,7 +9,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
     void DrawSpellIcon(ImDrawList* dl, const RE::SpellItem* spell, float cx, float cy, float iconSize);
 
     void DrawSlotVisual(ImDrawList* dl, ImVec2 center, float r, bool isActive, RE::SpellItem const* rSpell,
-                        RE::SpellItem const* lSpell, RE::FormID shoutFormID = 0);
+                        RE::SpellItem const* lSpell, RE::FormID shoutFormID = 0, bool forceOffset = false);
 
     void DrawRingCenter(ImDrawList* dl, ImVec2 c, float r = 4.f);
     void DrawModifierWidget(ImDrawList* dl, ImVec2 c, bool modHeld);

--- a/src/UI/SlotDrawer.h
+++ b/src/UI/SlotDrawer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <imgui.h>
 
-#include "RE/S/SpellItem.h"
+#include "PCH.h"
 
 namespace IntegratedMagic::HUD::SlotDrawer {
 

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -132,7 +132,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
     inline ImU32 LerpColor(ImU32 a, ImU32 b, float t) {
         const auto l8 = [](ImU32 ca, ImU32 cb, float tt) {
-            return static_cast<ImU32>(ca + static_cast<int>((static_cast<int>(cb) - static_cast<int>(ca)) * tt));
+            return ca + static_cast<int>((static_cast<int>(cb) - static_cast<int>(ca)) * tt);
         };
         return IM_COL32(l8(a & 0xFF, b & 0xFF, t), l8((a >> 8) & 0xFF, (b >> 8) & 0xFF, t),
                         l8((a >> 16) & 0xFF, (b >> 16) & 0xFF, t), l8((a >> 24) & 0xFF, (b >> 24) & 0xFF, t));
@@ -156,7 +156,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                 pts.push_back({center.x + std::cos(a) * r, center.y + std::sin(a) * r});
             }
         }
-        const int n = static_cast<int>(pts.size());
+        const auto n = static_cast<int>(pts.size());
         if (n < 3) return;
 
         ImU32 centerCol;
@@ -166,7 +166,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             const ImVec2 gc = {center.x, center.y - st.slotGradientRadialOffset * r};
             centerCol = gStart;
             for (int i = 0; i < n; ++i) {
-                const float dx = pts[i].x - gc.x, dy = pts[i].y - gc.y;
+                const float dx = pts[i].x - gc.x;
+                const float dy = pts[i].y - gc.y;
                 const float dist = std::sqrt(dx * dx + dy * dy);
                 const float t = std::clamp(dist / r, 0.f, 1.f);
                 edgeCol[i] = LerpColor(gStart, gEnd, t);
@@ -182,8 +183,10 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             }
         } else {
             const float rad = st.slotGradientAngle * kPI / 180.f;
-            const float ax = std::cos(rad), ay = std::sin(rad);
-            float minP = 0.f, maxP = 0.f;
+            const float ax = std::cos(rad);
+            const float ay = std::sin(rad);
+            float minP = 0.f;
+            float maxP = 0.f;
             std::vector<float> proj(n);
             for (int i = 0; i < n; ++i) {
                 proj[i] = (pts[i].x - center.x) * ax + (pts[i].y - center.y) * ay;
@@ -211,7 +214,9 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
     ImU32 ComputeIconTint() {
         const auto& st = Style();
-        float r = 1.f, g = 1.f, b = 1.f;
+        float r = 1.f;
+        float g = 1.f;
+        float b = 1.f;
         const float alpha = st.iconAlpha / 255.f;
 
         if ((st.iconTintColor >> 24) > 0) {
@@ -227,9 +232,9 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         if (st.iconSaturation < 255) {
             const float sat = st.iconSaturation / 255.f;
             const float gray = r * 0.299f + g * 0.587f + b * 0.114f;
-            r = gray + (r - gray) * sat;
-            g = gray + (g - gray) * sat;
-            b = gray + (b - gray) * sat;
+            r = std::lerp(gray, r, sat);
+            g = std::lerp(gray, g, sat);
+            b = std::lerp(gray, b, sat);
         }
 
         const float bri = st.iconBrightness / 128.f;
@@ -248,11 +253,12 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
         } else {
             switch (st.slotCornerStyle) {
-                case CornerStyle::Square:
+                using enum IntegratedMagic::CornerStyle;
+                case Square:
                     dl->PathRect({center.x - r, center.y - r}, {center.x + r, center.y + r}, 0.f);
                     break;
-                case CornerStyle::Notched:
-                case CornerStyle::Chamfered: {
+                case Notched:
+                case Chamfered: {
                     const float c = std::clamp(st.slotCornerSize, 0.f, r * 0.8f);
                     dl->PathLineTo({center.x - r + c, center.y - r});
                     dl->PathLineTo({center.x + r - c, center.y - r});
@@ -264,7 +270,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                     dl->PathLineTo({center.x - r, center.y - r + c});
                     break;
                 }
-                case CornerStyle::Round:
+                case Round:
                 default:
                     dl->PathArcTo(center, r, 0.f, 2.f * kPI, 48);
                     break;
@@ -300,18 +306,35 @@ namespace IntegratedMagic::HUD::SlotDrawer {
     }
 
     void DrawGlowShape(ImDrawList* dl, ImVec2 c, float r, ImU32 glowCol) {
-        const auto& shape = StyleConfig::Get().slotShape;
+        const auto& st = Style();
         const ImU32 base = glowCol & 0x00FFFFFFu;
-        const auto baseA = static_cast<int>((glowCol >> 24) & 0xFF);
-        if (shape.useCustomShape && shape.vertices.size() >= 3) {
-            for (int i = 5; i >= 1; --i) {
-                const ImU32 layer = base | (static_cast<ImU32>(baseA / (i + 1)) << 24);
-                StrokeSlotShape(dl, c, r + static_cast<float>(i) * 2.5f, layer, 1.2f);
+        const auto baseA = static_cast<int>(((glowCol >> 24) & 0xFF) * std::clamp(st.glowIntensity, 0.f, 2.f));
+        if (baseA == 0) return;
+
+        const int n = std::clamp(static_cast<int>(st.glowLayers), 1, 5);
+        const float step = std::max(0.5f, st.glowRadius);
+        const bool custom = st.slotShape.useCustomShape && st.slotShape.vertices.size() >= 3;
+
+        if (st.glowStyle == GlowStyle::Fill || st.glowStyle == GlowStyle::Both) {
+            const ImU32 fillCol = base | (static_cast<ImU32>(baseA / 4) << 24);
+            const float fillR = r + step * static_cast<float>(n);
+            if (custom) {
+                for (const auto& t : PolyFill::Triangulate(st.slotShape.vertices, c.x, c.y, fillR))
+                    dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, fillCol);
+            } else {
+                PathSlotShape(dl, c, fillR);
+                dl->PathFillConvex(fillCol);
             }
-        } else {
-            for (int i = 5; i >= 1; --i) {
+        }
+
+        if (st.glowStyle == GlowStyle::Ring || st.glowStyle == GlowStyle::Both) {
+            for (int i = n; i >= 1; --i) {
                 const ImU32 layer = base | (static_cast<ImU32>(baseA / (i + 1)) << 24);
-                dl->AddCircle(c, r + static_cast<float>(i) * 2.5f, layer, 48, 1.2f);
+                const float layerR = r + static_cast<float>(i) * step;
+                if (custom)
+                    StrokeSlotShape(dl, c, layerR, layer, 1.2f);
+                else
+                    dl->AddCircle(c, layerR, layer, 48, 1.2f);
             }
         }
     }
@@ -391,17 +414,22 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
         if (isActive) {
             const double t = ImGui::GetTime();
-            const double pulse = 0.65 + 0.35 * std::sin(t * 4.5);
-            const ImU32 ring =
-                IM_COL32(255, static_cast<int>(210 * pulse), static_cast<int>(50 * pulse), st.slotRingActiveAlpha);
-            StrokeSlotShape(dl, center, r, ring, st.slotRingWidth);
-            StrokeSlotShape(dl, center, r + st.slotRingWidth + 0.5f, (ring & 0x00FFFFFFu) | (70u << 24), 1.0f);
+            const double pulse = 0.65 + 0.35 * std::sin(t * static_cast<double>(st.pulseSpeed));
+            const ImU32 baseRGB = st.slotRingActive & 0x00FFFFFFu;
+            const auto pulseAlpha = static_cast<int>(st.slotRingActiveAlpha * pulse);
+            const ImU32 ring = baseRGB | (static_cast<ImU32>(pulseAlpha) << 24);
+
+            StrokeSlotShape(dl, center, r, ring, st.slotRingWidthActive);
+
+            const ImU32 halo = baseRGB | (static_cast<ImU32>(static_cast<int>(pulseAlpha * 0.28f)) << 24);
+            StrokeSlotShape(dl, center, r + st.slotRingWidthActive + 0.5f, halo, 1.0f);
         } else {
-            StrokeSlotShape(dl, center, r, st.slotRingInactive, st.slotRingWidth * 0.5f);
+            StrokeSlotShape(dl, center, r, st.slotRingInactive, st.slotRingWidth);
         }
 
         if ((st.slotOuterRingColor >> 24) > 0) {
-            const float outerR = r + st.slotRingWidth + 1.5f;
+            const float activeW = isActive ? st.slotRingWidthActive : st.slotRingWidth;
+            const float outerR = r + activeW + 1.5f;
             StrokeSlotShape(dl, center, outerR, st.slotOuterRingColor, st.slotOuterRingWidth);
         }
 
@@ -553,7 +581,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         const float margin = st.buttonLabelMargin;
         const float totalW = validCount * iconSize + (validCount - 1) * spacing;
 
-        float startX = 0.f, startY = 0.f;
+        float startX = 0.f;
+        float startY = 0.f;
         switch (st.buttonLabelCorner) {
             case ButtonLabelCorner::Top:
                 startX = center.x - totalW * 0.5f;
@@ -572,7 +601,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                 startY = center.y - iconSize * 0.5f;
                 break;
             case ButtonLabelCorner::TowardCenter: {
-                const float dx = hudOrigin.x - center.x, dy = hudOrigin.y - center.y;
+                const float dx = hudOrigin.x - center.x;
+                const float dy = hudOrigin.y - center.y;
                 if (const float len = std::sqrt(dx * dx + dy * dy); len > 0.5f) {
                     const float ax = center.x + (dx / len) * (slotR + margin + iconSize * 0.5f);
                     const float ay = center.y + (dy / len) * (slotR + margin + iconSize * 0.5f);
@@ -585,7 +615,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                 break;
             }
             case ButtonLabelCorner::AwayFromCenter: {
-                const float dx = center.x - hudOrigin.x, dy = center.y - hudOrigin.y;
+                const float dx = center.x - hudOrigin.x;
+                const float dy = center.y - hudOrigin.y;
                 if (const float len = std::sqrt(dx * dx + dy * dy); len > 0.5f) {
                     const float ax = center.x + (dx / len) * (slotR + margin + iconSize * 0.5f);
                     const float ay = center.y + (dy / len) * (slotR + margin + iconSize * 0.5f);
@@ -611,7 +642,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
     void DrawSmallHUD(const ImGuiIO& io) {
         const auto& st = Style();
-        const int n = static_cast<int>(Slots::GetSlotCount());
+        const auto n = static_cast<int>(Slots::GetSlotCount());
         const int activeSlot = MagicState::Get().ActiveSlot();
         const bool modHeld = !MagicState::Get().IsActive() && Input::IsModifierHeld();
 
@@ -672,7 +703,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
         auto ScaledCenter = [&](int idx) -> ImVec2 {
             const float scale = SlotAnimator::GetScale(idx);
-            const float rx = relPos[idx].x, ry = relPos[idx].y;
+            const float rx = relPos[idx].x;
+            const float ry = relPos[idx].y;
             const float len = std::sqrt(rx * rx + ry * ry);
             const float push = (scale - 1.f) * st.slotRadius;
             if (len > 0.5f) return {hudOrigin.x + rx + (rx / len) * push, hudOrigin.y + ry + (ry / len) * push};
@@ -711,7 +743,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
 
                 if (shID || is2H) {
                     const RE::FormID dispID = shID ? shID : lID;
-                    auto* f = RE::TESForm::LookupByID(dispID);
+                    auto const* f = RE::TESForm::LookupByID(dispID);
                     const char* name = f ? f->GetName() : "";
                     DrawWrappedLabelAbove(name, center.x - slotR, slotR * 2.f, slotTop, 4.f, true);
                 } else if (rSp || lSp) {

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -141,8 +141,13 @@ namespace IntegratedMagic::HUD::SlotDrawer {
     void FillSlotShape(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
         const auto& shape = StyleConfig::Get().slotShape;
         if (shape.vertices.size() >= 3) {
-            for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
-                dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
+            if (PolyFill::IsConvex(shape.vertices)) {
+                for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
+                dl->PathFillConvex(col);
+            } else {
+                for (const auto& t : PolyFill::Triangulate(shape.vertices, center.x, center.y, r))
+                    dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
+            }
         } else {
             dl->AddCircleFilled(center, r, col, 48);
         }
@@ -504,7 +509,15 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         const LayoutVec2 animHalf = [&] {
             LayoutVec2 h = SlotLayout::BoundingHalf(st.hudLayout, n, st.slotRadius * maxScale, st.ringRadius,
                                                     st.slotSpacing, st.gridColumns);
-            return LayoutVec2{h.x + kGlowPad, h.y + kGlowPad};
+            float extraY = kGlowPad;
+            if (st.showSpellNamesInHud) {
+                const bool iconsVisible = st.buttonLabelVisibility == ButtonLabelVisibility::Always ||
+                                          (st.buttonLabelVisibility == ButtonLabelVisibility::OnModifier && modHeld);
+                const float iconReserve = iconsVisible ? (st.buttonLabelIconSize + st.buttonLabelMargin) : 0.f;
+                const float textReserve = ImGui::GetTextLineHeight() * 3.f + 4.f + iconReserve;
+                extraY += textReserve;
+            }
+            return LayoutVec2{h.x + kGlowPad, h.y + extraY};
         }();
 
         const ImVec2 hudOrigin = ComputeHudCenter(io, {animHalf.x, animHalf.y});
@@ -545,10 +558,10 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             const bool is2H = !shID && !rID && lSp && SpellClassify::IsTwoHandedSpell(lSp);
             DrawSlotVisual(dl, center, slotR, active, is2H ? nullptr : rSp, is2H ? nullptr : lSp, is2H ? lID : shID);
 
-            if (st.showSpellNamesInHud) {
-                const float iconReserve = (st.buttonLabelVisibility != ButtonLabelVisibility::Never)
-                                              ? (st.buttonLabelIconSize + st.buttonLabelMargin)
-                                              : 0.f;
+            if (st.showSpellNamesInHud && !MagicState::Get().IsActive()) {
+                const bool iconsVisible = st.buttonLabelVisibility == ButtonLabelVisibility::Always ||
+                                          (st.buttonLabelVisibility == ButtonLabelVisibility::OnModifier && modHeld);
+                const float iconReserve = iconsVisible ? (st.buttonLabelIconSize + st.buttonLabelMargin) : 0.f;
                 const float slotTop = center.y - slotR - iconReserve;
 
                 if (shID || is2H) {
@@ -556,9 +569,26 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                     auto* f = RE::TESForm::LookupByID(dispID);
                     const char* name = f ? f->GetName() : "";
                     DrawWrappedLabelAbove(name, center.x - slotR, slotR * 2.f, slotTop, 4.f, true);
-                } else {
-                    if (lSp) DrawWrappedLabelAbove(lSp->GetName(), center.x - slotR, slotR, slotTop);
-                    if (rSp) DrawWrappedLabelAbove(rSp->GetName(), center.x, slotR, slotTop);
+                } else if (rSp || lSp) {
+                    const bool sameSpell = rSp && lSp && (rSp->GetFormID() == lSp->GetFormID());
+                    const bool onlyOne = (rSp != nullptr) != (lSp != nullptr);
+
+                    if (sameSpell || onlyOne) {
+                        const RE::SpellItem* sp = rSp ? rSp : lSp;
+                        DrawWrappedLabelAbove(sp->GetName(), center.x - slotR, slotR * 2.f, slotTop, 4.f, true);
+                    } else {
+                        constexpr float kPipeGap = 6.f;
+                        const float pipeW = ImGui::CalcTextSize("|").x;
+                        const float halfPipe = pipeW * 0.5f;
+
+                        DrawWrappedLabelAbove(lSp->GetName(), center.x - slotR, slotR - halfPipe - kPipeGap, slotTop);
+
+                        const float pipeH = ImGui::GetTextLineHeight();
+                        ImGui::SetCursorScreenPos({center.x - halfPipe, slotTop - 4.f - pipeH});
+
+                        DrawWrappedLabelAbove(rSp->GetName(), center.x + halfPipe + kPipeGap,
+                                              slotR - halfPipe - kPipeGap, slotTop);
+                    }
                 }
             }
         };

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -249,7 +249,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
     void PathSlotShape(ImDrawList* dl, ImVec2 center, float r) {
         const auto& st = Style();
         const auto& shape = st.slotShape;
-        if (shape.vertices.size() >= 3) {
+        if (shape.useCustomShape && shape.vertices.size() >= 3) {
             for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
         } else {
             switch (st.slotCornerStyle) {
@@ -286,7 +286,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             return;
         }
         const auto& shape = st.slotShape;
-        if (shape.vertices.size() >= 3) {
+        if (shape.useCustomShape && shape.vertices.size() >= 3) {
             if (PolyFill::IsConvex(shape.vertices)) {
                 for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
                 dl->PathFillConvex(col);

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -19,6 +19,7 @@
 #include "UI/SlotLayout.h"
 #include "UI/StyleConfig.h"
 #include "UI/TextureManager.h"
+#include "imgui_internal.h"
 
 namespace IntegratedMagic::HUD::SlotDrawer {
 
@@ -129,17 +130,156 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         }
     }
 
+    inline ImU32 LerpColor(ImU32 a, ImU32 b, float t) {
+        const auto l8 = [](ImU32 ca, ImU32 cb, float tt) {
+            return static_cast<ImU32>(ca + static_cast<int>((static_cast<int>(cb) - static_cast<int>(ca)) * tt));
+        };
+        return IM_COL32(l8(a & 0xFF, b & 0xFF, t), l8((a >> 8) & 0xFF, (b >> 8) & 0xFF, t),
+                        l8((a >> 16) & 0xFF, (b >> 16) & 0xFF, t), l8((a >> 24) & 0xFF, (b >> 24) & 0xFF, t));
+    }
+
+    void FillSlotShapeGradient(ImDrawList* dl, ImVec2 center, float r) {
+        const auto& st = Style();
+        const ImU32 gStart = st.slotGradientStart;
+        const ImU32 gEnd = st.slotGradientEnd;
+
+        const auto& shape = st.slotShape;
+        std::vector<ImVec2> pts;
+        if (shape.vertices.size() >= 3) {
+            pts.reserve(shape.vertices.size());
+            for (const auto& v : shape.vertices) pts.push_back({center.x + v.x * r, center.y + v.y * r});
+        } else {
+            constexpr int kSeg = 48;
+            pts.reserve(kSeg);
+            for (int i = 0; i < kSeg; ++i) {
+                const float a = 2.f * kPI * static_cast<float>(i) / kSeg;
+                pts.push_back({center.x + std::cos(a) * r, center.y + std::sin(a) * r});
+            }
+        }
+        const int n = static_cast<int>(pts.size());
+        if (n < 3) return;
+
+        ImU32 centerCol;
+        std::vector<ImU32> edgeCol(n);
+
+        if (st.slotGradientType == GradientType::Radial) {
+            const ImVec2 gc = {center.x, center.y - st.slotGradientRadialOffset * r};
+            centerCol = gStart;
+            for (int i = 0; i < n; ++i) {
+                const float dx = pts[i].x - gc.x, dy = pts[i].y - gc.y;
+                const float dist = std::sqrt(dx * dx + dy * dy);
+                const float t = std::clamp(dist / r, 0.f, 1.f);
+                edgeCol[i] = LerpColor(gStart, gEnd, t);
+            }
+
+            const ImVec2 uv = dl->_Data->TexUvWhitePixel;
+            dl->PrimReserve(n * 3, n * 3);
+            for (int i = 0; i < n; ++i) {
+                const int j = (i + 1) % n;
+                dl->PrimVtx(gc, uv, centerCol);
+                dl->PrimVtx(pts[i], uv, edgeCol[i]);
+                dl->PrimVtx(pts[j], uv, edgeCol[j]);
+            }
+        } else {
+            const float rad = st.slotGradientAngle * kPI / 180.f;
+            const float ax = std::cos(rad), ay = std::sin(rad);
+            float minP = 0.f, maxP = 0.f;
+            std::vector<float> proj(n);
+            for (int i = 0; i < n; ++i) {
+                proj[i] = (pts[i].x - center.x) * ax + (pts[i].y - center.y) * ay;
+                minP = std::min(minP, proj[i]);
+                maxP = std::max(maxP, proj[i]);
+            }
+            const float range = maxP - minP;
+            const float centerProj = 0.f;
+            const float ct = (range > 0.f) ? (centerProj - minP) / range : 0.5f;
+            centerCol = LerpColor(gStart, gEnd, std::clamp(ct, 0.f, 1.f));
+            for (int i = 0; i < n; ++i) {
+                const float t = (range > 0.f) ? (proj[i] - minP) / range : 0.5f;
+                edgeCol[i] = LerpColor(gStart, gEnd, std::clamp(t, 0.f, 1.f));
+            }
+            const ImVec2 uv = dl->_Data->TexUvWhitePixel;
+            dl->PrimReserve(n * 3, n * 3);
+            for (int i = 0; i < n; ++i) {
+                const int j = (i + 1) % n;
+                dl->PrimVtx(center, uv, centerCol);
+                dl->PrimVtx(pts[i], uv, edgeCol[i]);
+                dl->PrimVtx(pts[j], uv, edgeCol[j]);
+            }
+        }
+    }
+
+    ImU32 ComputeIconTint() {
+        const auto& st = Style();
+        float r = 1.f, g = 1.f, b = 1.f;
+        const float alpha = st.iconAlpha / 255.f;
+
+        if ((st.iconTintColor >> 24) > 0) {
+            const float ta = ((st.iconTintColor >> 24) & 0xFF) / 255.f;
+            const float tr = (st.iconTintColor & 0xFF) / 255.f;
+            const float tg = ((st.iconTintColor >> 8) & 0xFF) / 255.f;
+            const float tb = ((st.iconTintColor >> 16) & 0xFF) / 255.f;
+            r = 1.f - ta + tr * ta;
+            g = 1.f - ta + tg * ta;
+            b = 1.f - ta + tb * ta;
+        }
+
+        if (st.iconSaturation < 255) {
+            const float sat = st.iconSaturation / 255.f;
+            const float gray = r * 0.299f + g * 0.587f + b * 0.114f;
+            r = gray + (r - gray) * sat;
+            g = gray + (g - gray) * sat;
+            b = gray + (b - gray) * sat;
+        }
+
+        const float bri = st.iconBrightness / 128.f;
+        r = std::clamp(r * bri, 0.f, 1.f);
+        g = std::clamp(g * bri, 0.f, 1.f);
+        b = std::clamp(b * bri, 0.f, 1.f);
+
+        return IM_COL32(static_cast<int>(r * 255.f), static_cast<int>(g * 255.f), static_cast<int>(b * 255.f),
+                        static_cast<int>(alpha * 255.f));
+    }
+
     void PathSlotShape(ImDrawList* dl, ImVec2 center, float r) {
-        const auto& shape = StyleConfig::Get().slotShape;
+        const auto& st = Style();
+        const auto& shape = st.slotShape;
         if (shape.vertices.size() >= 3) {
             for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
         } else {
-            dl->PathArcTo(center, r, 0.f, 2.f * kPI, 48);
+            switch (st.slotCornerStyle) {
+                case CornerStyle::Square:
+                    dl->PathRect({center.x - r, center.y - r}, {center.x + r, center.y + r}, 0.f);
+                    break;
+                case CornerStyle::Notched:
+                case CornerStyle::Chamfered: {
+                    const float c = std::clamp(st.slotCornerSize, 0.f, r * 0.8f);
+                    dl->PathLineTo({center.x - r + c, center.y - r});
+                    dl->PathLineTo({center.x + r - c, center.y - r});
+                    dl->PathLineTo({center.x + r, center.y - r + c});
+                    dl->PathLineTo({center.x + r, center.y + r - c});
+                    dl->PathLineTo({center.x + r - c, center.y + r});
+                    dl->PathLineTo({center.x - r + c, center.y + r});
+                    dl->PathLineTo({center.x - r, center.y + r - c});
+                    dl->PathLineTo({center.x - r, center.y - r + c});
+                    break;
+                }
+                case CornerStyle::Round:
+                default:
+                    dl->PathArcTo(center, r, 0.f, 2.f * kPI, 48);
+                    break;
+            }
         }
     }
 
     void FillSlotShape(ImDrawList* dl, ImVec2 center, float r, ImU32 col) {
-        const auto& shape = StyleConfig::Get().slotShape;
+        const auto& st = Style();
+
+        if (st.slotGradientType != GradientType::None) {
+            FillSlotShapeGradient(dl, center, r);
+            return;
+        }
+        const auto& shape = st.slotShape;
         if (shape.vertices.size() >= 3) {
             if (PolyFill::IsConvex(shape.vertices)) {
                 for (const auto& v : shape.vertices) dl->PathLineTo({center.x + v.x * r, center.y + v.y * r});
@@ -149,7 +289,8 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                     dl->AddTriangleFilled({t.ax, t.ay}, {t.bx, t.by}, {t.cx, t.cy}, col);
             }
         } else {
-            dl->AddCircleFilled(center, r, col, 48);
+            PathSlotShape(dl, center, r);
+            dl->PathFillConvex(col);
         }
     }
 
@@ -189,7 +330,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         if (!img.valid()) return;
         const float half = iconSize * 0.5f;
         dl->AddImage(reinterpret_cast<ImTextureID>(img.texture), {cx - half, cy - half}, {cx + half, cy + half},
-                     {0.f, 0.f}, {1.f, 1.f}, IM_COL32(255, 255, 255, Style().iconAlpha));
+                     {0.f, 0.f}, {1.f, 1.f}, ComputeIconTint());
     }
 
     void DrawSlotVisual(ImDrawList* dl, ImVec2 center, float r, bool isActive, RE::SpellItem const* rSpell,
@@ -232,8 +373,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             if (img.valid()) {
                 const float half = iconSize * 0.6f;
                 dl->AddImage(reinterpret_cast<ImTextureID>(img.texture), {center.x - half, center.y - half},
-                             {center.x + half, center.y + half}, {0.f, 0.f}, {1.f, 1.f},
-                             IM_COL32(255, 255, 255, st.iconAlpha));
+                             {center.x + half, center.y + half}, {0.f, 0.f}, {1.f, 1.f}, ComputeIconTint());
             }
         } else {
             const float off = r * st.iconOffsetFactor;
@@ -258,6 +398,11 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             StrokeSlotShape(dl, center, r + st.slotRingWidth + 0.5f, (ring & 0x00FFFFFFu) | (70u << 24), 1.0f);
         } else {
             StrokeSlotShape(dl, center, r, st.slotRingInactive, st.slotRingWidth * 0.5f);
+        }
+
+        if ((st.slotOuterRingColor >> 24) > 0) {
+            const float outerR = r + st.slotRingWidth + 1.5f;
+            StrokeSlotShape(dl, center, outerR, st.slotOuterRingColor, st.slotOuterRingWidth);
         }
 
         if (!rSpell && !lSpell && !shoutFormID) {

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -8,11 +8,12 @@
 
 #include "Config/Config.h"
 #include "Config/Slots.h"
-#include "HudState.h"
 #include "Input/Input.h"
 #include "PCH.h"
 #include "State/SpellClassify.h"
 #include "State/State.h"
+#include "UI/HudState.h"
+#include "UI/HudTextUtil.h"
 #include "UI/PolyFill.h"
 #include "UI/SlotAnimator.h"
 #include "UI/SlotLayout.h"
@@ -187,7 +188,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
     }
 
     void DrawSlotVisual(ImDrawList* dl, ImVec2 center, float r, bool isActive, RE::SpellItem const* rSpell,
-                        RE::SpellItem const* lSpell, RE::FormID shoutFormID) {
+                        RE::SpellItem const* lSpell, RE::FormID shoutFormID, bool forceOffset) {
         const auto rPal = SpellPalette(rSpell);
         const auto lPal = SpellPalette(lSpell);
 
@@ -231,8 +232,16 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             }
         } else {
             const float off = r * st.iconOffsetFactor;
-            if (rSpell) DrawSpellIcon(dl, rSpell, center.x + off, center.y, iconSize);
-            if (lSpell) DrawSpellIcon(dl, lSpell, center.x - off, center.y, iconSize);
+            const bool sameSpell = rSpell && lSpell && (rSpell->GetFormID() == lSpell->GetFormID());
+            const bool onlyOne = (rSpell != nullptr) != (lSpell != nullptr);
+
+            if (!forceOffset && (sameSpell || onlyOne)) {
+                const RE::SpellItem* sp = rSpell ? rSpell : lSpell;
+                DrawSpellIcon(dl, sp, center.x, center.y, iconSize);
+            } else {
+                if (rSpell) DrawSpellIcon(dl, rSpell, center.x + off, center.y, iconSize);
+                if (lSpell) DrawSpellIcon(dl, lSpell, center.x - off, center.y, iconSize);
+            }
         }
 
         if (isActive) {
@@ -535,6 +544,23 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             auto const* lSp = lID ? RE::TESForm::LookupByID<RE::SpellItem>(lID) : nullptr;
             const bool is2H = !shID && !rID && lSp && SpellClassify::IsTwoHandedSpell(lSp);
             DrawSlotVisual(dl, center, slotR, active, is2H ? nullptr : rSp, is2H ? nullptr : lSp, is2H ? lID : shID);
+
+            if (st.showSpellNamesInHud) {
+                const float iconReserve = (st.buttonLabelVisibility != ButtonLabelVisibility::Never)
+                                              ? (st.buttonLabelIconSize + st.buttonLabelMargin)
+                                              : 0.f;
+                const float slotTop = center.y - slotR - iconReserve;
+
+                if (shID || is2H) {
+                    const RE::FormID dispID = shID ? shID : lID;
+                    auto* f = RE::TESForm::LookupByID(dispID);
+                    const char* name = f ? f->GetName() : "";
+                    DrawWrappedLabelAbove(name, center.x - slotR, slotR * 2.f, slotTop, 4.f, true);
+                } else {
+                    if (lSp) DrawWrappedLabelAbove(lSp->GetName(), center.x - slotR, slotR, slotTop);
+                    if (rSp) DrawWrappedLabelAbove(rSp->GetName(), center.x, slotR, slotTop);
+                }
+            }
         };
 
         for (int i = 0; i < n; ++i)

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -220,7 +220,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
         const float alpha = st.iconAlpha / 255.f;
 
         if ((st.iconTintColor >> 24) > 0) {
-            const float ta = ((st.iconTintColor >> 24) & 0xFF) / 255.f;
+            const float ta = ((st.iconTintColor >> 24) & 0xFF) / 255.f * std::clamp(st.iconTintStrength, 0.f, 1.f);
             const float tr = (st.iconTintColor & 0xFF) / 255.f;
             const float tg = ((st.iconTintColor >> 8) & 0xFF) / 255.f;
             const float tb = ((st.iconTintColor >> 16) & 0xFF) / 255.f;

--- a/src/UI/Slotdrawer.cpp
+++ b/src/UI/Slotdrawer.cpp
@@ -1,7 +1,6 @@
 #include "SlotDrawer.h"
 
 #include <imgui.h>
-#include "UI/PolyFill.h"
 
 #include <chrono>
 #include <cmath>
@@ -12,9 +11,9 @@
 #include "HudState.h"
 #include "Input/Input.h"
 #include "PCH.h"
-#include "RE/P/PlayerCharacter.h"
 #include "State/SpellClassify.h"
 #include "State/State.h"
+#include "UI/PolyFill.h"
 #include "UI/SlotAnimator.h"
 #include "UI/SlotLayout.h"
 #include "UI/StyleConfig.h"
@@ -415,8 +414,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
                 break;
             case ButtonLabelCorner::TowardCenter: {
                 const float dx = hudOrigin.x - center.x, dy = hudOrigin.y - center.y;
-                const float len = std::sqrt(dx * dx + dy * dy);
-                if (len > 0.5f) {
+                if (const float len = std::sqrt(dx * dx + dy * dy); len > 0.5f) {
                     const float ax = center.x + (dx / len) * (slotR + margin + iconSize * 0.5f);
                     const float ay = center.y + (dy / len) * (slotR + margin + iconSize * 0.5f);
                     startX = ax - totalW * 0.5f;
@@ -429,8 +427,7 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             }
             case ButtonLabelCorner::AwayFromCenter: {
                 const float dx = center.x - hudOrigin.x, dy = center.y - hudOrigin.y;
-                const float len = std::sqrt(dx * dx + dy * dy);
-                if (len > 0.5f) {
+                if (const float len = std::sqrt(dx * dx + dy * dy); len > 0.5f) {
                     const float ax = center.x + (dx / len) * (slotR + margin + iconSize * 0.5f);
                     const float ay = center.y + (dy / len) * (slotR + margin + iconSize * 0.5f);
                     startX = ax - totalW * 0.5f;
@@ -491,12 +488,6 @@ namespace IntegratedMagic::HUD::SlotDrawer {
             }
             for (int i = n; i < SlotLayout::kMaxSlots; ++i) s_labelAlpha[i] = 0.f;
         }
-
-        const LayoutVec2 fixedHalf = [&] {
-            LayoutVec2 h =
-                SlotLayout::BoundingHalf(st.hudLayout, n, st.slotRadius, st.ringRadius, st.slotSpacing, st.gridColumns);
-            return LayoutVec2{h.x + kGlowPad, h.y + kGlowPad};
-        }();
 
         float maxScale = SlotAnimator::MaxPossibleScale();
         for (int i = 0; i < n; ++i) maxScale = std::max(maxScale, SlotAnimator::GetScale(i));

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -184,6 +184,10 @@ namespace IntegratedMagic {
         {
             const char* v = ini.GetValue("HUD", "UseTextureForSlotBg", nullptr);
             if (v) useTextureForSlotBg = (_stricmp(v, "true") == 0 || std::strcmp(v, "1") == 0);
+            {
+                const char* v2 = ini.GetValue("HUD", "ShowSpellNames", nullptr);
+                if (v2) showSpellNamesInHud = (_stricmp(v2, "true") == 0 || std::strcmp(v2, "1") == 0);
+            }
         }
 
         buttonIconType = GetButtonIconType(ini, "General", "ButtonIconType", buttonIconType);
@@ -307,6 +311,7 @@ namespace IntegratedMagic {
         setFloat("HUD", "SlotSpacing", slotSpacing);
         setInt("HUD", "GridColumns", gridColumns);
         setBool("HUD", "UseTextureForSlotBg", useTextureForSlotBg);
+        setBool("HUD", "ShowSpellNames", showSpellNamesInHud);
 
         ini.SetValue("General", "ButtonIconType", kButtonIconTypeNames[static_cast<int>(buttonIconType)]);
 

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -220,8 +220,10 @@ namespace IntegratedMagic {
         slotBgActive = GetColor(ini, "Colors", "SlotBgActive", slotBgActive);
         slotBgInactive = GetColor(ini, "Colors", "SlotBgInactive", slotBgInactive);
         slotRingInactive = GetColor(ini, "Colors", "SlotRingInactive", slotRingInactive);
+        slotRingActive = GetColor(ini, "Colors", "SlotRingActive", slotRingActive);
         slotRingActiveAlpha = GetU8(ini, "Colors", "SlotRingActiveAlpha", slotRingActiveAlpha);
         slotRingWidth = GetFloat(ini, "Colors", "SlotRingWidth", slotRingWidth);
+        slotRingWidthActive = GetFloat(ini, "Colors", "SlotRingWidthActive", slotRingWidthActive);
         iconAlpha = GetU8(ini, "Colors", "IconAlpha", iconAlpha);
         emptySlotColor = GetColor(ini, "Colors", "EmptySlotColor", emptySlotColor);
 
@@ -292,6 +294,23 @@ namespace IntegratedMagic {
 
         overlayColor = GetColor(ini, "Popup", "OverlayColor", overlayColor);
         vignetteStrength = GetFloat(ini, "Popup", "VignetteStrength", vignetteStrength);
+
+        {
+            const char* v = ini.GetValue("Glow", "Style", nullptr);
+            if (v) {
+                const std::string s{v};
+                if (s == "Fill" || s == "1")
+                    glowStyle = GlowStyle::Fill;
+                else if (s == "Both" || s == "2")
+                    glowStyle = GlowStyle::Both;
+                else
+                    glowStyle = GlowStyle::Ring;
+            }
+        }
+        glowLayers = GetU8(ini, "Glow", "Layers", glowLayers);
+        glowRadius = GetFloat(ini, "Glow", "Radius", glowRadius);
+        glowIntensity = GetFloat(ini, "Glow", "Intensity", glowIntensity);
+        pulseSpeed = GetFloat(ini, "Glow", "PulseSpeed", pulseSpeed);
 
         spdlog::info("[StyleConfig] styles.ini carregado.");
     }
@@ -398,8 +417,10 @@ namespace IntegratedMagic {
         setColor("Colors", "SlotBgActive", slotBgActive);
         setColor("Colors", "SlotBgInactive", slotBgInactive);
         setColor("Colors", "SlotRingInactive", slotRingInactive);
+        setColor("Colors", "SlotRingActive", slotRingActive);
         setU8("Colors", "SlotRingActiveAlpha", slotRingActiveAlpha);
         setFloat("Colors", "SlotRingWidth", slotRingWidth);
+        setFloat("Colors", "SlotRingWidthActive", slotRingWidthActive);
         setU8("Colors", "IconAlpha", iconAlpha);
         setColor("Colors", "EmptySlotColor", emptySlotColor);
         setColor("Colors", "RingCenterFill", ringCenterFill);
@@ -444,6 +465,13 @@ namespace IntegratedMagic {
 
         setColor("Popup", "OverlayColor", overlayColor);
         setFloat("Popup", "VignetteStrength", vignetteStrength);
+
+        static constexpr const char* kGlowStyleNames[] = {"Ring", "Fill", "Both"};
+        ini.SetValue("Glow", "Style", kGlowStyleNames[static_cast<int>(glowStyle)]);
+        setU8("Glow", "Layers", glowLayers);
+        setFloat("Glow", "Radius", glowRadius);
+        setFloat("Glow", "Intensity", glowIntensity);
+        setFloat("Glow", "PulseSpeed", pulseSpeed);
 
         ini.SaveFile(kPath);
         spdlog::info("[StyleConfig] styles.ini salvo.");

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -283,7 +283,9 @@ namespace IntegratedMagic {
         iconTintColor = GetColor(ini, "Icons", "TintColor", iconTintColor);
         iconSaturation = GetU8(ini, "Icons", "Saturation", iconSaturation);
         iconBrightness = GetU8(ini, "Icons", "Brightness", iconBrightness);
+        iconTintStrength = GetFloat(ini, "Icons", "TintStrength", iconTintStrength);
 
+        textColor = GetColor(ini, "TextShadow", "TextColor", textColor);
         {
             const char* v = ini.GetValue("TextShadow", "Enabled", nullptr);
             if (v) textShadowEnabled = (_stricmp(v, "true") == 0 || std::strcmp(v, "1") == 0);
@@ -457,7 +459,9 @@ namespace IntegratedMagic {
         setColor("Icons", "TintColor", iconTintColor);
         setU8("Icons", "Saturation", iconSaturation);
         setU8("Icons", "Brightness", iconBrightness);
+        setFloat("Icons", "TintStrength", iconTintStrength);
 
+        setColor("TextShadow", "TextColor", textColor);
         setBool("TextShadow", "Enabled", textShadowEnabled);
         setColor("TextShadow", "Color", textShadowColor);
         setFloat("TextShadow", "OffsetX", textShadowOffsetX);

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -162,6 +162,8 @@ namespace IntegratedMagic {
         popupRingRadius = GetFloat(ini, "Popup", "RingRadius", popupRingRadius);
         popupSlotGap = GetFloat(ini, "Popup", "SlotGap", popupSlotGap);
         popupLayout = GetLayout(ini, "Popup", "Layout", popupLayout);
+        popupOffsetX = GetFloat(ini, "Popup", "OffsetX", popupOffsetX);
+        popupOffsetY = GetFloat(ini, "Popup", "OffsetY", popupOffsetY);
         modeWidgetW = GetFloat(ini, "Popup", "ModeWidgetWidth", modeWidgetW);
         iconSizeFactor = GetFloat(ini, "Icons", "SizeFactor", iconSizeFactor);
         iconOffsetFactor = GetFloat(ini, "Icons", "OffsetFactor", iconOffsetFactor);
@@ -331,6 +333,8 @@ namespace IntegratedMagic {
         setFloat("Popup", "ModeWidgetWidth", modeWidgetW);
         setU8("Popup", "OverlayAlpha", overlayAlpha);
         ini.SetValue("Popup", "Layout", kLayoutNames[static_cast<int>(popupLayout)]);
+        setFloat("Popup", "OffsetX", popupOffsetX);
+        setFloat("Popup", "OffsetY", popupOffsetY);
 
         setFloat("Icons", "SizeFactor", iconSizeFactor);
         setFloat("Icons", "OffsetFactor", iconOffsetFactor);

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -154,7 +154,14 @@ namespace IntegratedMagic {
             sscanf_s(val.c_str(), "%f,%f", &x, &y);
             verts.push_back({x, y});
         }
-        if (verts.empty()) shape.SetCircle();
+        {
+            const char* v = ini.GetValue("SlotShape", "UseCustomShape", nullptr);
+            if (v) shape.useCustomShape = (_stricmp(v, "true") == 0 || std::strcmp(v, "1") == 0);
+        }
+        if (verts.empty()) {
+            shape.SetCircle();
+            shape.useCustomShape = false;
+        }
 
         slotRadius = GetFloat(ini, "HUD", "SlotRadius", slotRadius);
         ringRadius = GetFloat(ini, "HUD", "RingRadius", ringRadius);
@@ -168,6 +175,7 @@ namespace IntegratedMagic {
         iconSizeFactor = GetFloat(ini, "Icons", "SizeFactor", iconSizeFactor);
         iconOffsetFactor = GetFloat(ini, "Icons", "OffsetFactor", iconOffsetFactor);
         overlayAlpha = GetU8(ini, "Popup", "OverlayAlpha", overlayAlpha);
+        vignetteColor = GetColor(ini, "Popup", "VignetteColor", vignetteColor);
 
         slotActiveScale = GetFloat(ini, "HUD", "SlotActiveScale", slotActiveScale);
         slotModifierScale = GetFloat(ini, "HUD", "SlotModifierScale", slotModifierScale);
@@ -359,6 +367,7 @@ namespace IntegratedMagic {
             ini.SetValue("SlotShape", key.c_str(), val.c_str());
         }
         ini.SetLongValue("SlotShape", "Count", static_cast<long>(verts.size()));
+        ini.SetBoolValue("SlotShape", "UseCustomShape", slotShape.useCustomShape);
 
         ini.SetValue("Font", "Path", font.path.c_str());
         setFloat("Font", "Size", font.size);
@@ -412,6 +421,7 @@ namespace IntegratedMagic {
         ini.SetValue("Popup", "Layout", kLayoutNames[static_cast<int>(popupLayout)]);
         setFloat("Popup", "OffsetX", popupOffsetX);
         setFloat("Popup", "OffsetY", popupOffsetY);
+        setColor("Popup", "VignetteColor", vignetteColor);
 
         setFloat("Icons", "SizeFactor", iconSizeFactor);
         setFloat("Icons", "OffsetFactor", iconOffsetFactor);

--- a/src/UI/StyleConfig.cpp
+++ b/src/UI/StyleConfig.cpp
@@ -242,6 +242,57 @@ namespace IntegratedMagic {
         defaultGlow = GetColor(ini, "SchoolColors", "DefaultGlow", defaultGlow);
         emptyFill = GetColor(ini, "SchoolColors", "EmptyFill", emptyFill);
 
+        {
+            const char* v = ini.GetValue("Gradient", "Type", nullptr);
+            if (v) {
+                const std::string s{v};
+                if (s == "Radial" || s == "1")
+                    slotGradientType = GradientType::Radial;
+                else if (s == "Linear" || s == "2")
+                    slotGradientType = GradientType::Linear;
+                else
+                    slotGradientType = GradientType::None;
+            }
+        }
+        slotGradientStart = GetColor(ini, "Gradient", "StartColor", slotGradientStart);
+        slotGradientEnd = GetColor(ini, "Gradient", "EndColor", slotGradientEnd);
+        slotGradientAngle = GetFloat(ini, "Gradient", "Angle", slotGradientAngle);
+        slotGradientRadialOffset = GetFloat(ini, "Gradient", "RadialOffset", slotGradientRadialOffset);
+
+        slotOuterRingColor = GetColor(ini, "Colors", "SlotOuterRingColor", slotOuterRingColor);
+        slotOuterRingWidth = GetFloat(ini, "Colors", "SlotOuterRingWidth", slotOuterRingWidth);
+
+        {
+            const char* v = ini.GetValue("HUD", "CornerStyle", nullptr);
+            if (v) {
+                const std::string s{v};
+                if (s == "Square" || s == "1")
+                    slotCornerStyle = CornerStyle::Square;
+                else if (s == "Notched" || s == "2")
+                    slotCornerStyle = CornerStyle::Notched;
+                else if (s == "Chamfered" || s == "3")
+                    slotCornerStyle = CornerStyle::Chamfered;
+                else
+                    slotCornerStyle = CornerStyle::Round;
+            }
+        }
+        slotCornerSize = GetFloat(ini, "HUD", "CornerSize", slotCornerSize);
+
+        iconTintColor = GetColor(ini, "Icons", "TintColor", iconTintColor);
+        iconSaturation = GetU8(ini, "Icons", "Saturation", iconSaturation);
+        iconBrightness = GetU8(ini, "Icons", "Brightness", iconBrightness);
+
+        {
+            const char* v = ini.GetValue("TextShadow", "Enabled", nullptr);
+            if (v) textShadowEnabled = (_stricmp(v, "true") == 0 || std::strcmp(v, "1") == 0);
+        }
+        textShadowColor = GetColor(ini, "TextShadow", "Color", textShadowColor);
+        textShadowOffsetX = GetFloat(ini, "TextShadow", "OffsetX", textShadowOffsetX);
+        textShadowOffsetY = GetFloat(ini, "TextShadow", "OffsetY", textShadowOffsetY);
+
+        overlayColor = GetColor(ini, "Popup", "OverlayColor", overlayColor);
+        vignetteStrength = GetFloat(ini, "Popup", "VignetteStrength", vignetteStrength);
+
         spdlog::info("[StyleConfig] styles.ini carregado.");
     }
 
@@ -367,6 +418,32 @@ namespace IntegratedMagic {
         setColor("SchoolColors", "DefaultFill", defaultFill);
         setColor("SchoolColors", "DefaultGlow", defaultGlow);
         setColor("SchoolColors", "EmptyFill", emptyFill);
+
+        static constexpr const char* kGradientNames[] = {"None", "Radial", "Linear"};
+        ini.SetValue("Gradient", "Type", kGradientNames[static_cast<int>(slotGradientType)]);
+        setColor("Gradient", "StartColor", slotGradientStart);
+        setColor("Gradient", "EndColor", slotGradientEnd);
+        setFloat("Gradient", "Angle", slotGradientAngle);
+        setFloat("Gradient", "RadialOffset", slotGradientRadialOffset);
+
+        setColor("Colors", "SlotOuterRingColor", slotOuterRingColor);
+        setFloat("Colors", "SlotOuterRingWidth", slotOuterRingWidth);
+
+        static constexpr const char* kCornerNames[] = {"Round", "Square", "Notched", "Chamfered"};
+        ini.SetValue("HUD", "CornerStyle", kCornerNames[static_cast<int>(slotCornerStyle)]);
+        setFloat("HUD", "CornerSize", slotCornerSize);
+
+        setColor("Icons", "TintColor", iconTintColor);
+        setU8("Icons", "Saturation", iconSaturation);
+        setU8("Icons", "Brightness", iconBrightness);
+
+        setBool("TextShadow", "Enabled", textShadowEnabled);
+        setColor("TextShadow", "Color", textShadowColor);
+        setFloat("TextShadow", "OffsetX", textShadowOffsetX);
+        setFloat("TextShadow", "OffsetY", textShadowOffsetY);
+
+        setColor("Popup", "OverlayColor", overlayColor);
+        setFloat("Popup", "VignetteStrength", vignetteStrength);
 
         ini.SaveFile(kPath);
         spdlog::info("[StyleConfig] styles.ini salvo.");

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -199,6 +199,7 @@ namespace IntegratedMagic {
 
         std::uint32_t overlayColor = 0xFF000000u;
         float vignetteStrength = 0.f;
+        std::uint32_t vignetteColor = 0xFF000000u;
 
         GlowStyle glowStyle = GlowStyle::Ring;
         std::uint8_t glowLayers = 5;

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -189,7 +189,9 @@ namespace IntegratedMagic {
         std::uint32_t iconTintColor = 0x00000000u;
         std::uint8_t iconSaturation = 255;
         std::uint8_t iconBrightness = 128;
+        float iconTintStrength = 1.f;
 
+        std::uint32_t textColor = 0xFFAAAAAAu;
         bool textShadowEnabled = false;
         std::uint32_t textShadowColor = 0xCC000000u;
         float textShadowOffsetX = 1.f;

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -86,6 +86,8 @@ namespace IntegratedMagic {
         float popupSlotGap = 24.f;
         HudLayoutType popupLayout = HudLayoutType::Circular;
         float modeWidgetW = 58.f;
+        float popupOffsetX = 0.f;
+        float popupOffsetY = 0.f;
         float iconSizeFactor = 0.90f;
         float iconOffsetFactor = 0.28f;
         std::uint8_t overlayAlpha = 160;

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -62,6 +62,12 @@ namespace IntegratedMagic {
         Chamfered = 3,
     };
 
+    enum class GlowStyle : std::uint8_t {
+        Ring = 0,
+        Fill = 1,
+        Both = 2,
+    };
+
     struct FontConfig {
         std::string path = "";
         float size = 28.f;
@@ -142,8 +148,10 @@ namespace IntegratedMagic {
         std::uint32_t slotBgInactive = 0xC80C0C0Cu;
 
         std::uint32_t slotRingInactive = 0x96464646u;
+        std::uint32_t slotRingActive = 0xFFD23200u;
         std::uint8_t slotRingActiveAlpha = 245;
         float slotRingWidth = 2.5f;
+        float slotRingWidthActive = 2.5f;
 
         std::uint8_t iconAlpha = 220;
 
@@ -189,6 +197,12 @@ namespace IntegratedMagic {
 
         std::uint32_t overlayColor = 0xFF000000u;
         float vignetteStrength = 0.f;
+
+        GlowStyle glowStyle = GlowStyle::Ring;
+        std::uint8_t glowLayers = 5;
+        float glowRadius = 2.5f;
+        float glowIntensity = 1.f;
+        float pulseSpeed = 4.5f;
 
         void Load();
         void Save();

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -49,6 +49,19 @@ namespace IntegratedMagic {
         HideOnPress = 2,
     };
 
+    enum class GradientType : std::uint8_t {
+        None = 0,
+        Radial = 1,
+        Linear = 2,
+    };
+
+    enum class CornerStyle : std::uint8_t {
+        Round = 0,
+        Square = 1,
+        Notched = 2,
+        Chamfered = 3,
+    };
+
     struct FontConfig {
         std::string path = "";
         float size = 28.f;
@@ -152,6 +165,30 @@ namespace IntegratedMagic {
         std::uint32_t defaultFill = 0xA0646464u;
         std::uint32_t defaultGlow = 0x00000000u;
         std::uint32_t emptyFill = 0x78282828u;
+
+        GradientType slotGradientType = GradientType::None;
+        std::uint32_t slotGradientStart = 0x00000000u;
+        std::uint32_t slotGradientEnd = 0x00000000u;
+        float slotGradientAngle = 0.f;
+        float slotGradientRadialOffset = 0.f;
+
+        std::uint32_t slotOuterRingColor = 0x00000000u;
+        float slotOuterRingWidth = 1.f;
+
+        CornerStyle slotCornerStyle = CornerStyle::Round;
+        float slotCornerSize = 8.f;
+
+        std::uint32_t iconTintColor = 0x00000000u;
+        std::uint8_t iconSaturation = 255;
+        std::uint8_t iconBrightness = 128;
+
+        bool textShadowEnabled = false;
+        std::uint32_t textShadowColor = 0xCC000000u;
+        float textShadowOffsetX = 1.f;
+        float textShadowOffsetY = 1.f;
+
+        std::uint32_t overlayColor = 0xFF000000u;
+        float vignetteStrength = 0.f;
 
         void Load();
         void Save();

--- a/src/UI/StyleConfig.h
+++ b/src/UI/StyleConfig.h
@@ -107,6 +107,7 @@ namespace IntegratedMagic {
         int gridColumns = 2;
 
         bool useTextureForSlotBg = false;
+        bool showSpellNamesInHud = false;
 
         ButtonIconType buttonIconType = ButtonIconType::Xbox;
 


### PR DESCRIPTION
## Summary by Sourcery

Expand HUD slot visual customization and input handling while improving slot assignment and equip-conflict behavior.

New Features:
- Allow assigning the currently hovered magic item in the Magic Menu directly to a slot using that slot's hotkey.
- Add extensive HUD customization for slot visuals, including gradients, outer rings, corner styles, glow behavior, icon tinting, text appearance, and popup overlay/vignette options.
- Support showing spell names above HUD and popup slots with automatic wrapping and alignment.
- Enable configurable popup HUD positioning via X/Y offsets.
- Introduce capture mode for hotkey binding that can read keyboard, mouse buttons, and gamepad inputs via XInput.

Bug Fixes:
- Prevent foreign spells, powers, shouts, shields, and other items from silently conflicting with an active slot by more accurately detecting conflicts in each hand and forcing a controlled exit when needed.
- Avoid stuck mouse button state when the game window loses focus by clearing mouse key state on focus loss.
- Ensure magic menu visibility is correctly toggled when opening and closing the detailed HUD popup.

Enhancements:
- Refine slot rendering with configurable active/inactive ring widths, animated pulse speed, and optional outer ring drawing.
- Improve custom slot shape handling by distinguishing between corner-style shapes and fully custom shapes, with optimized convex filling.
- Centralize HUD text drawing and wrapping into a reusable utility for consistent styling and shadow rendering.
- Tweak small HUD layout and bounding box calculations to account for optional spell names and button labels.
- Make equip event handling for spells, shouts, and gear more explicit and readable, including better debug logging and separation of cases.
- Delay finalizing magic session exit slightly after spell fire events to better match casting behavior.
- Modernize various enum usages with std::to_underlying and clean up include paths for input and HUD components.

Build:
- Link against xinput.lib to support gamepad polling for capture mode.